### PR TITLE
ZaDark 23.6.1 (Details at CHANGELOG.md)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## ZaDark 23.6.1
+> PC 8.4 && Web 8.16
+
+### Added
+- **[Core]** Bổ sung cho chức năng "Thay đổi cỡ chữ của tin nhắn" : Áp dụng cho tin nhắn có hình ảnh
+
+### Changed
+- **[ZaDark Settings]**
+  - Giảm sáng cho biểu tượng màu trắng của công tắc (switch)
+  - Thay đổi địa chỉ Phản hồi (sử dụng Canny thay Google Forms)
+  - Hợp nhất tính năng "Ẩn Tin nhắn gần nhất ở Danh sách trò chuyện" và "Ẩn Tin nhắn trong Cuộc trò chuyện" thành "Chống nhìn trộm tin nhắn" (Rê chuột vào dấu chấm hỏi để xem giải thích chi tiết)
+  - Cập nhật một số chi tiết nhỏ khác
+- **[Source code]**
+  - Thay đổi flow thoát Zalo PC
+  - Thay đổi cấu trúc đặt tên cho tập tin cài đặt ngắn gọn hơn
+
 ## ZaDark 23.5.7
 > PC 8.3 && Web 8.15
 

--- a/contributing/DEVELOPMENT.md
+++ b/contributing/DEVELOPMENT.md
@@ -88,28 +88,28 @@ yarn dist
 # ➜ Output:
 # dist/
 #   chrome/
-#     ZaDark-Chrome-[VERSION].zip
+#     ZaDark Chrome [VERSION].zip
 #
 #   firefox/
-#     ZaDark-Firefox-[VERSION].zip
+#     ZaDark Firefox [VERSION].zip
 #
 #   opera/
-#     ZaDark-Opera-[VERSION].zip
+#     ZaDark Opera [VERSION].zip
 #
 #   edge/
-#     ZaDark-Edge-[VERSION].zip
+#     ZaDark Edge [VERSION].zip
 #
 #   macos/
-#     ZaDark-macOS-[VERSION]
-#     ZaDark-macOS-[VERSION].pkg
+#     ZaDark [VERSION] exec
+#     ZaDark [VERSION].pkg
 #
 #   windows/
-#     ZaDark-Windows-[VERSION].exe
-#     ZaDark-Windows-[VERSION].zip
+#     ZaDark [VERSION].exe
+#     ZaDark [VERSION].zip
 ```
 
-- For Google Chrome, Firefox, Opera and Microsoft Edge: Distribute `dist/[PLATFORM]/ZaDark-[PLATFORM]-[VERSION].zip` to Store
-- For Windows: Distribute `dist/windows/ZaDark-Windows-[VERSION].zip` directly to users
+- For Google Chrome, Firefox, Opera and Microsoft Edge: Distribute `dist/[PLATFORM]/ZaDark [PLATFORM] [VERSION].zip` to Store
+- For Windows: Distribute `dist/windows/ZaDark [VERSION].zip` directly to users
 - For macOS: Let's see the [Codesign macOS Application](#codesign-macos-application)
 
 ### Codesign && Notarize macOS Application
@@ -117,13 +117,13 @@ yarn dist
 1. Create the configuration file `.env` with the content from `.env.example`.
 2. Run the command `yarn macos:pkgbuild` to perform the signing and package building process:
    - This command will automatically sign the application.
-   - After signing, it will generate an installer package named `dist/macos/ZaDark-macOS-[VERSION].pkg`.
+   - After signing, it will generate an installer package named `dist/macos/ZaDark [VERSION].pkg`.
 3. If the previous command succeeds, run the command `yarn macos:notarize` to notarize the installer package:
    - This command will submit the package for notarization to Apple's notary service.
    - It will wait for the notarization process to complete.
 4. Once notarization is complete, run the command `yarn macos:staple` to staple the notary ticket to the installer package:
    - This step ensures that the notarization information is attached to the package.
-5. Congratulations! You now have a signed and notarized installer package located at `dist/macos/ZaDark-macOS-[VERSION].pkg`.
-6. Distribute the `ZaDark-macOS-[VERSION].pkg` package directly to users for installation.
+5. Congratulations! You now have a signed and notarized installer package located at `dist/macos/ZaDark [VERSION].pkg`.
+6. Distribute the `ZaDark [VERSION].pkg` package directly to users for installation.
 
 > Read more about notarization here: https://developer.apple.com/documentation/xcode/notarizing_macos_software_before_distribution

--- a/dist-utils.js
+++ b/dist-utils.js
@@ -6,15 +6,13 @@ const operaManifest = require('./src/web/vendor/opera/manifest.json')
 const edgeManifest = require('./src/web/vendor/edge/manifest.json')
 const pcPackageJSON = require('./src/pc/package.json')
 
-const dot2Underscore = (v = '') => v.replace(/\./g, '_')
-
 const FILE_NAME = {
-  CHROME: `ZaDark-Chrome-${dot2Underscore(chromeManifest.version)}`,
-  FIREFOX: `ZaDark-Firefox-${dot2Underscore(firefoxManifest.version)}`,
-  OPERA: `ZaDark-Opera-${dot2Underscore(operaManifest.version)}`,
-  EDGE: `ZaDark-Edge-${dot2Underscore(edgeManifest.version)}`,
-  MACOS: `ZaDark-macOS-${dot2Underscore(pcPackageJSON.version)}`,
-  WINDOWS: `ZaDark-Windows-${dot2Underscore(pcPackageJSON.version)}`
+  CHROME: `ZaDark Chrome ${chromeManifest.version}`,
+  FIREFOX: `ZaDark Firefox ${firefoxManifest.version}`,
+  OPERA: `ZaDark Opera ${operaManifest.version}`,
+  EDGE: `ZaDark Edge ${edgeManifest.version}`,
+  MACOS: `ZaDark ${pcPackageJSON.version} exec`,
+  WINDOWS: `ZaDark ${pcPackageJSON.version}`
 }
 
 const FILE_EXT_ORIGINAL = {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadark",
   "description": "Dark Mode tốt nhất cho Zalo",
-  "version": "23.5.7",
+  "version": "23.6.1",
   "repository": "https://github.com/quaric/zadark.git",
   "author": {
     "name": "Quaric",

--- a/src/core/scss/_zadark-prv.scss
+++ b/src/core/scss/_zadark-prv.scss
@@ -35,16 +35,13 @@
     }
   }
 
-  .conv-item:hover,
-  &:not(.zadark-prv--thread-chat-message) .conv-item.selected {
-    .conv-item-body__main .conv-message {
-      &::after {
-        opacity: 0;
-      }
+  .conv-item:hover .conv-item-body__main .conv-message {
+    &::after {
+      opacity: 0;
+    }
 
-      * {
-        opacity: 1;
-      }
+    * {
+      opacity: 1;
     }
   }
 }

--- a/src/core/scss/zadark-popup.scss
+++ b/src/core/scss/zadark-popup.scss
@@ -37,6 +37,8 @@ html[data-zadark-theme="light"] #zadark-popup {
   --zadark-blue-300: #0068ff;
   --zadark-blue-base: #0068ff;
 
+  --zadark-switch-slider: #fff;
+
   .zadark-publisher__lockup--dark {
     display: inline-block;
   }
@@ -73,6 +75,8 @@ html[data-zadark-theme="dark"] #zadark-popup {
   --zadark-blue-400: #035bdc;
   --zadark-blue-300: #3989ff;
   --zadark-blue-base: #3989ff;
+
+  --zadark-switch-slider: var(--zadark-neutral-300);
 
   .zadark-publisher__lockup--light {
     display: inline-block;
@@ -333,12 +337,10 @@ html[data-zadark-theme="dark"] #zadark-popup {
       user-select: none;
 
       &--helper {
-        display: flex;
-        align-items: center;
-
         &-icon {
+          position: relative;
+          bottom: -2px;
           display: inline-flex;
-          margin-left: 6px;
           color: var(--zadark-neutral-500);
         }
       }
@@ -377,7 +379,7 @@ html[data-zadark-theme="dark"] #zadark-popup {
         width: 12px;
         left: 2px;
         bottom: 2px;
-        background-color: white;
+        background-color: var(--zadark-switch-slider);
         -webkit-transition: 0.25s;
         transition: 0.25s;
         border-radius: 50rem;

--- a/src/core/scss/zadark.scss
+++ b/src/core/scss/zadark.scss
@@ -2093,17 +2093,18 @@ body.zadark {
     }
   }
 
-  &.zadark-prv--latest-message {
+  &.zadark-prv--thread-chat-message {
     @include prv.prv-lastest-message();
-  }
 
-  &.zadark-prv--thread-chat-message #chatView {
-    @include prv.prv-thread-chat-message();
+    #chatView {
+      @include prv.prv-thread-chat-message();
+    }
   }
 
   // Conv font size
   .card--text,
-  .msg-info-popup {
+  .msg-info-popup,
+  .img-msg-v2__cap {
     a,
     .text,
     .editor-input {

--- a/src/pc/assets/js/zadark.js
+++ b/src/pc/assets/js/zadark.js
@@ -11,9 +11,7 @@ const ZADARK_THEME_KEY = '@ZaDark:THEME'
 const ZADARK_FONT_KEY = '@ZaDark:FONT'
 const ZADARK_FONT_SIZE_KEY = '@ZaDark:FONT_SIZE'
 
-const ZADARK_ENABLED_HIDE_LATEST_MESSAGE_KEY = '@ZaDark:ENABLED_HIDE_LATEST_MESSAGE'
 const ZADARK_ENABLED_HIDE_THREAD_CHAT_MESSAGE_KEY = '@ZaDark:ENABLED_HIDE_THREAD_CHAT_MESSAGE'
-
 const ZADARK_ENABLED_BLOCK_TYPING_KEY = '@ZaDark:ENABLED_BLOCK_TYPING'
 const ZADARK_ENABLED_BLOCK_DELIVERED_KEY = '@ZaDark:ENABLED_BLOCK_DELIVERED'
 const ZADARK_ENABLED_BLOCK_SEEN_KEY = '@ZaDark:ENABLED_BLOCK_SEEN'
@@ -54,14 +52,6 @@ window.zadark.storage = {
 
   saveFontSize: (fontSize) => {
     return localStorage.setItem(ZADARK_FONT_SIZE_KEY, fontSize)
-  },
-
-  saveEnabledHideLatestMessage: (isEnabled) => {
-    return localStorage.setItem(ZADARK_ENABLED_HIDE_LATEST_MESSAGE_KEY, isEnabled)
-  },
-
-  getEnabledHideLatestMessage: () => {
-    return localStorage.getItem(ZADARK_ENABLED_HIDE_LATEST_MESSAGE_KEY) === 'true'
   },
 
   saveEnabledHideThreadChatMessage: (isEnabled) => {
@@ -153,15 +143,6 @@ window.zadark.utils = {
     this.setFontSizeAttr(fontSize)
   },
 
-  refreshHideLatestMessage: function () {
-    const isEnabled = window.zadark.storage.getEnabledHideLatestMessage()
-    if (isEnabled) {
-      document.body.classList.add('zadark-prv--latest-message')
-    } else {
-      document.body.classList.remove('zadark-prv--latest-message')
-    }
-  },
-
   refreshHideThreadChatMessage: function () {
     const isEnabled = window.zadark.storage.getEnabledHideThreadChatMessage()
     if (isEnabled) {
@@ -197,18 +178,12 @@ window.zadark.utils = {
 
   getRatingURL: function () {
     return 'https://sourceforge.net/projects/zadark/reviews/new?stars=5'
-  },
-
-  getFeedbackURL: function (platformKey = 'win32') {
-    const platformName = platformKey === 'darwin' ? 'macOS' : 'Windows'
-    return `https://docs.google.com/forms/d/e/1FAIpQLSfy8AXwBO-myPPkbXboq5ubeMa0MCMWJTl0Ke66qCyCAiWG9g/viewform?usp=pp_url&entry.454875478=${platformName}`
   }
 }
 
 window.zadark.utils.refreshPageTheme()
 window.zadark.utils.refreshPageFont()
 window.zadark.utils.refreshPageFontSize()
-window.zadark.utils.refreshHideLatestMessage()
 window.zadark.utils.refreshHideThreadChatMessage()
 window.zadark.utils.loadBlockSettings()
 
@@ -237,9 +212,7 @@ const selectThemeElName = '#js-select-theme input:radio[name="theme"]'
 const selectFontElName = '#js-select-font'
 const selectFontSizeElName = '#js-select-font-size'
 
-const switchHideLatestMessageElName = '#js-switch-hide-latest-message'
 const switchHideThreadChatMessageElName = '#js-switch-hide-thread-chat-message'
-
 const switchBlockTypingElName = '#js-switch-block-typing'
 const switchBlockSeenElName = '#js-switch-block-seen'
 const switchBlockDeliveredElName = '#js-switch-block-delivered'
@@ -283,12 +256,6 @@ function handleFontSizeChange () {
   window.zadark.utils.refreshPageFontSize()
 }
 
-function handleHideLatestMessageChange () {
-  const isEnabled = $(this).is(':checked')
-  window.zadark.storage.saveEnabledHideLatestMessage(isEnabled)
-  window.zadark.utils.refreshHideLatestMessage()
-}
-
 function handleHideThreadChatMessageChange () {
   const isEnabled = $(this).is(':checked')
   window.zadark.storage.saveEnabledHideThreadChatMessage(isEnabled)
@@ -315,7 +282,7 @@ const iconQuestionSVG = `
 `
 
 const zadarkButtonHTML = `
-  <div id="div_Main_TabZaDark" class="clickable leftbar-tab flx flx-col flx-al-c flx-center rel" data-id="div_Main_TabZaDark" data-translate-title="STR_MENU_ZADARK" title="ZaDark">
+  <div id="div_Main_TabZaDark" class="clickable leftbar-tab flx flx-col flx-al-c flx-center rel" data-id="div_Main_TabZaDark" data-translate-title="STR_MENU_ZADARK" title="ZaDark Settings">
     <svg width="24" height="24" viewBox="0 0 336 336" fill="none" xmlns="http://www.w3.org/2000/svg">
       <path d="M0.000806072 167.484C0.284527 74.7006 75.3948 -0.284182 167.764 0.000809684C181.016 0.0416946 193.907 1.63028 206.268 4.59743C208.09 5.03469 209.381 6.66172 209.399 8.5429C209.417 10.4241 208.158 12.076 206.345 12.5488C151.203 26.9302 110.418 77.1876 110.235 137.092C110.017 208.377 167.37 266.343 238.337 266.562C263.059 266.638 286.161 259.7 305.789 247.614C307.386 246.631 309.444 246.867 310.78 248.185C312.116 249.504 312.386 251.568 311.435 253.188C282.267 302.895 228.343 336.189 166.737 335.999C74.3674 335.714 -0.282915 260.267 0.000806072 167.484Z" fill="currentColor"/>
       <path d="M284.255 176.183C286.752 166.785 288 159.507 288 154.35C288 152.974 286.315 151.37 282.944 149.536C279.698 147.702 277.513 146.785 276.389 146.785C275.391 146.785 274.891 146.9 274.891 147.129C273.768 150.109 271.458 154.063 267.963 158.991C264.467 163.92 261.72 167.186 259.723 168.791C256.477 170.625 249.61 171.542 239.124 171.542C228.762 171.542 223.581 171.14 223.581 170.338C223.581 167.817 231.633 156.069 247.738 135.095C263.968 114.12 275.953 99.6218 283.693 91.5989C284.692 90.682 285.191 90.0516 285.191 89.7077C285.191 86.2693 284.504 83.1748 283.131 80.4241C281.883 77.6733 280.759 75.8968 279.76 75.0946C277.513 74.4069 269.398 74.063 255.416 74.063C241.558 74.063 229.011 74.808 217.775 76.298C217.526 76.298 215.591 75.6103 211.97 74.235C208.35 72.745 204.792 72 201.296 72C200.797 72 199.735 74.1777 198.112 78.533C196.614 82.8882 195.179 87.8166 193.805 93.3181C192.557 98.8195 191.933 102.946 191.933 105.696C191.933 106.613 193.493 107.931 196.614 109.65C199.86 111.37 202.357 112.229 204.105 112.229L206.539 108.447C211.533 100.424 214.904 96.1261 216.652 95.553C220.397 93.8338 226.889 92.9742 236.127 92.9742C245.491 92.9742 250.172 93.318 250.172 94.0057C250.172 95.2665 245.553 101.628 236.315 113.089C227.076 124.436 217.213 136.585 206.727 149.536C196.365 162.487 190.185 170.911 188.187 174.808C188.062 175.266 188 176.47 188 178.418C188 180.367 188.687 182.946 190.06 186.155C191.558 189.364 192.931 190.968 194.18 190.968L252.794 189.421C256.914 189.421 259.473 189.479 260.472 189.593L263.281 190.281C269.149 191.427 273.456 192 276.202 192C277.576 192 278.449 191.828 278.824 191.484C279.948 190.567 281.758 185.467 284.255 176.183Z" fill="currentColor"/>
@@ -338,7 +305,7 @@ const popupHeaderHTML = `
       </span>
 
       <span class="zadark-popup__header__menu-item zadark-popup__header__menu-divider">
-        <a href="${window.zadark.utils.getFeedbackURL(document.documentElement.getAttribute('data-zadark-platform'))}" title="Phản hồi" target="_blank">Phản hồi</a>
+        <a href="https://zadark.canny.io" title="Phản hồi" target="_blank">Phản hồi</a>
       </span>
 
       <span class="zadark-popup__header__menu-item">
@@ -394,7 +361,7 @@ const popupMainHTML = `
         </div>
 
         <div class="select-font">
-          <label class="select-font__label">Thay đổi cỡ chữ trong Trò chuyện</label>
+          <label class="select-font__label">Thay đổi cỡ chữ của tin nhắn</label>
 
           <select id="js-select-font-size" class="zadark-select zadark-select--text-right">
             <option value="small">Nhỏ</option>
@@ -413,20 +380,9 @@ const popupMainHTML = `
         <div class="zadark-panel__body">
           <div class="zadark-switch__list">
             <div class="zadark-switch">
-              <label class="zadark-switch__label zadark-switch__label--helper" for="js-switch-hide-latest-message">
-                Ẩn&nbsp;<strong>Tin nhắn gần nhất</strong>&nbsp;trong Danh sách trò chuyện
-                <span class="zadark-switch__label--helper-icon" data-tippy-content="<p>Tin nhắn gần nhất trong Danh sách trò chuyện (bên trái) sẽ được ẩn để hạn chế người khác nhìn trộm tin nhắn.</p><p>Để xem nội dung, bạn di chuyển chuột hoặc nhấn vào Cuộc trò chuyện.</p>"></span>
-              </label>
-              <label class="zadark-switch__checkbox">
-                <input class="zadark-switch__input" type="checkbox" id="js-switch-hide-latest-message">
-                <span class="zadark-switch__slider"></span>
-              </label>
-            </div>
-
-            <div class="zadark-switch">
               <label class="zadark-switch__label zadark-switch__label--helper" for="js-switch-hide-thread-chat-message">
-                Ẩn&nbsp;<strong>Tin nhắn</strong>&nbsp;trong Trò chuyện${!window.zadark.utils.isMac() ? ' & Thông báo' : ''}
-                <span class="zadark-switch__label--helper-icon" data-tippy-content="<p>Tin nhắn trong Trò chuyện${!window.zadark.utils.isMac() ? ' & Thông báo' : ''} sẽ được làm mờ để hạn chế người khác nhìn trộm tin nhắn.</p><p>Để xem nội dung, bạn di chuyển chuột vào Vùng hiển thị tin nhắn. Di chuyển chuột khỏi Vùng hiển thị tin nhắn để ẩn tin nhắn.</p>"></span>
+                Chống nhìn trộm tin nhắn
+                <span class="zadark-switch__label--helper-icon" data-tippy-content="<p>Danh sách trò chuyện sẽ ẩn đi các tin nhắn gần nhất để ngăn người khác xem trộm. Để xem nội dung tin nhắn, bạn chỉ cần di chuột vào cuộc trò chuyện tương ứng.</p><p>Tin nhắn trong trò chuyện cũng sẽ được làm mờ để bảo vệ quyền riêng tư của bạn. Để xem nội dung tin nhắn, hãy di chuột vào vùng hiển thị tin nhắn. Khi bạn di chuột ra khỏi vùng này, tin nhắn sẽ được ẩn đi.</p>${!window.zadark.utils.isMac() ? '<p>Cuối cùng, tin nhắn trong hộp thoại thông báo cũng sẽ được ẩn đi để ngăn người khác xem trộm.</p>' : ''}"></span>
               </label>
               <label class="zadark-switch__checkbox">
                 <input class="zadark-switch__input" type="checkbox" id="js-switch-hide-thread-chat-message">
@@ -435,7 +391,7 @@ const popupMainHTML = `
             </div>
 
             <div class="zadark-switch">
-              <label class="zadark-switch__label" for="js-switch-block-typing">Ẩn trạng thái <strong>Đang soạn tin nhắn ...</strong></label>
+              <label class="zadark-switch__label" for="js-switch-block-typing">Ẩn trạng thái <strong>Đang soạn tin (Typing) ...</strong></label>
               <label class="zadark-switch__checkbox">
                 <input class="zadark-switch__input" type="checkbox" id="js-switch-block-typing">
                 <span class="zadark-switch__slider"></span>
@@ -443,7 +399,7 @@ const popupMainHTML = `
             </div>
 
             <div class="zadark-switch">
-              <label class="zadark-switch__label" for="js-switch-block-delivered">Ẩn trạng thái <strong>Đã nhận</strong> tin nhắn</label>
+              <label class="zadark-switch__label" for="js-switch-block-delivered">Ẩn trạng thái <strong>Đã nhận (Received)</strong></label>
               <label class="zadark-switch__checkbox">
                 <input class="zadark-switch__input" type="checkbox" id="js-switch-block-delivered">
                 <span class="zadark-switch__slider"></span>
@@ -451,7 +407,7 @@ const popupMainHTML = `
             </div>
 
             <div class="zadark-switch">
-              <label class="zadark-switch__label" for="js-switch-block-seen">Ẩn trạng thái <strong>Đã xem</strong> tin nhắn</label>
+              <label class="zadark-switch__label" for="js-switch-block-seen">Ẩn trạng thái <strong>Đã xem (Seen)</strong></label>
               <label class="zadark-switch__checkbox">
                 <input class="zadark-switch__input" type="checkbox" id="js-switch-block-seen">
                 <span class="zadark-switch__slider"></span>
@@ -491,9 +447,6 @@ const loadPopupState = () => {
 
   const fontSize = window.zadark.storage.getFontSize()
   setSelectFontSize(fontSize)
-
-  const enabledHideLatestMessage = window.zadark.storage.getEnabledHideLatestMessage()
-  setSwitch(switchHideLatestMessageElName, enabledHideLatestMessage)
 
   const enabledHideThreadChatMessage = window.zadark.storage.getEnabledHideThreadChatMessage()
   setSwitch(switchHideThreadChatMessageElName, enabledHideThreadChatMessage)
@@ -582,9 +535,7 @@ const loadZaDarkPopup = () => {
   $(selectFontElName).on('change', handleFontChange)
   $(selectFontSizeElName).on('change', handleFontSizeChange)
 
-  $(switchHideLatestMessageElName).on('change', handleHideLatestMessageChange)
   $(switchHideThreadChatMessageElName).on('change', handleHideThreadChatMessageChange)
-
   $(switchBlockTypingElName).on('change', handleBlockSettingsChange(switchBlockTypingElName, 'block_typing'))
   $(switchBlockSeenElName).on('change', handleBlockSettingsChange(switchBlockSeenElName, 'block_seen'))
   $(switchBlockDeliveredElName).on('change', handleBlockSettingsChange(switchBlockDeliveredElName, 'block_delivered'))

--- a/src/pc/index.js
+++ b/src/pc/index.js
@@ -4,7 +4,7 @@ const inquirer = require('inquirer')
 const crossSpawn = require('cross-spawn')
 
 const zadarkPC = require('./zadark-pc')
-const { print, printError, open, killProcess, clearScreen } = require('./utils')
+const { print, printError, openWebsite, clearScreen, killProcesses } = require('./utils')
 
 const {
   ZADARK_VERSION,
@@ -75,19 +75,15 @@ const renderNotes = () => {
 }
 
 const handleQuitZalo = async () => {
-  const zaloPID = await zadarkPC.getZaloProcessId()
+  const zaloPIDs = await zadarkPC.getZaloProcessIds()
 
-  if (zaloPID === null) {
+  if (!Array.isArray(zaloPIDs) || !zaloPIDs?.length) {
     return
   }
 
   print('')
   print(chalk('>> Dang thoat Zalo PC ...'))
-
-  const success = killProcess(zaloPID)
-  if (!success) {
-    throw new Error('Khong the thoat Zalo PC. Vui long thoat Zalo PC truoc khi cai dat ZaDark.' + zaloPID)
-  }
+  killProcesses(zaloPIDs)
 }
 
 const handleInstall = async (zaloResDirList) => {
@@ -102,7 +98,7 @@ const handleInstall = async (zaloResDirList) => {
   }
 
   print('')
-  print(chalk.greenBright('>> Da cai dat ZaDark. Vui long khoi dong lai Zalo PC.'))
+  print(chalk.greenBright('>> Da cai dat ZaDark. Vui long mo lai Zalo PC.'))
 }
 
 const handleUninstall = async (zaloResDirList) => {
@@ -117,7 +113,14 @@ const handleUninstall = async (zaloResDirList) => {
   }
 
   print('')
-  print(chalk.greenBright('>> Da go cai dat ZaDark. Vui long khoi dong lai Zalo PC.'))
+  print(chalk.greenBright('>> Da go cai dat ZaDark. Vui long mo lai Zalo PC.'))
+}
+
+const handleOpenDocs = () => {
+  print(chalk.magentaBright.bold('[HUONG DAN]'))
+  print('')
+  print('>> Truy cap :', chalk.underline(CONTACT_URL))
+  openWebsite(CONTACT_URL)
 }
 
 const requestQuitTermProgram = () => {
@@ -171,10 +174,7 @@ const requestQuitTermProgram = () => {
       }
 
       case '3': {
-        print(chalk.magentaBright.bold('[HUONG DAN]'))
-        print('')
-        print('>> Truy cap :', chalk.underline(CONTACT_URL))
-        open(CONTACT_URL)
+        handleOpenDocs()
         break
       }
 
@@ -191,7 +191,7 @@ const requestQuitTermProgram = () => {
     print('')
     printError(error.message)
 
-    open(COMMON_ERRORS_URL)
+    openWebsite(COMMON_ERRORS_URL)
     print(`Xem huong dan : ${COMMON_ERRORS_URL}`)
     //
   } finally {

--- a/src/pc/package.json
+++ b/src/pc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadark-pc",
   "description": "Dark Mode tốt nhất cho Zalo",
-  "version": "8.3",
+  "version": "8.4",
   "main": "index.js",
   "repository": "https://github.com/quaric/zadark.git",
   "author": {

--- a/src/pc/utils.js
+++ b/src/pc/utils.js
@@ -10,9 +10,9 @@ const printDebug = (...args) => IS_DEV ? print(chalk.gray(...args)) : null
 const printError = (...args) => console.log(chalk.redBright(args.join(' ')))
 const clearScreen = () => console.clear()
 
-const open = (url) => {
-  const start = (IS_MAC ? 'open' : IS_WIN ? 'start' : 'xdg-open')
-  crossSpawn(start, [url])
+const openWebsite = (url) => {
+  const cmd = (IS_MAC ? 'open' : IS_WIN ? 'start' : 'xdg-open')
+  crossSpawn(cmd, [url], { shell: true })
 }
 
 const copyRecursiveSync = (src, dest) => {
@@ -44,10 +44,14 @@ const isRoot = () => {
   return IS_MAC ? process.getuid && process.getuid() === 0 : false
 }
 
-const killProcess = (processId) => {
-  const args = IS_MAC ? [processId.toString()] : ['/F', '/PID', processId.toString()]
+const killProcess = (pid) => {
+  const args = IS_MAC ? [pid.toString()] : ['/F', '/PID', pid.toString()]
   const result = crossSpawn.sync(IS_MAC ? 'kill' : 'taskkill', args)
   return result?.status === 0
+}
+
+const killProcesses = (processIds = []) => {
+  processIds.forEach((pid) => killProcess(pid))
 }
 
 module.exports = {
@@ -56,9 +60,10 @@ module.exports = {
   printError,
   clearScreen,
 
-  open,
+  openWebsite,
   copyRecursiveSync,
   isRoot,
 
-  killProcess
+  killProcess,
+  killProcesses
 }

--- a/src/pc/zadark-pc.js
+++ b/src/pc/zadark-pc.js
@@ -28,15 +28,18 @@ const getZaloResDirList = (customZaloPath) => {
   return resources.sort()
 }
 
-const getZaloProcessId = async () => {
+const getZaloProcessIds = async () => {
   const processes = await psList()
 
   const processName = IS_MAC
     ? ['zalo', '/applications/za']
     : ['zalo.exe']
 
-  const process = processes.find((process) => processName.includes(process.name.toLowerCase()))
-  return process?.pid ?? null
+  const pids = processes
+    .filter((process) => processName.includes(process.name.toLowerCase()))
+    .map((process) => process.pid)
+
+  return pids
 }
 
 const removeZaDarkCSSAndJS = ({ headElement, bodyElement }) => {
@@ -334,7 +337,7 @@ const uninstallZaDark = async (zaloDir) => {
 
 module.exports = {
   getZaloResDirList,
-  getZaloProcessId,
+  getZaloProcessIds,
 
   installZaDark,
   uninstallZaDark

--- a/src/web/js/popup.js
+++ b/src/web/js/popup.js
@@ -5,14 +5,12 @@
 */
 
 const ratingElName = '#js-ext-rating'
-const feedbackElName = '#js-ext-feedback'
 const versionElName = '#js-ext-version'
 const selectThemeElName = '#js-select-theme input:radio[name="theme"]'
 const selectFontElName = '#js-select-font'
 const selectFontSizeElName = '#js-select-font-size'
 const manifestData = window.zadark.browser.getManifest()
 
-const switchHideLatestMessageElName = '#js-switch-hide-latest-message'
 const switchHideThreadChatMessageElName = '#js-switch-hide-thread-chat-message'
 const switchBlockTypingElName = '#js-switch-block-typing'
 const switchBlockSeenElName = '#js-switch-block-seen'
@@ -23,14 +21,12 @@ const MSG_ACTIONS = {
   CHANGE_THEME: '@ZaDark:CHANGE_THEME',
   CHANGE_FONT: '@ZaDark:CHANGE_FONT',
   CHANGE_FONT_SIZE: '@ZaDark:CHANGE_FONT_SIZE',
-  CHANGE_HIDE_LATEST_MESSAGE: '@ZaDark:CHANGE_HIDE_LATEST_MESSAGE',
   CHANGE_HIDE_THREAD_CHAT_MESSAGE: '@ZaDark:CHANGE_HIDE_THREAD_CHAT_MESSAGE',
   GET_ENABLED_BLOCKING_RULE_IDS: '@ZaDark:GET_ENABLED_BLOCKING_RULE_IDS',
   UPDATE_ENABLED_BLOCKING_RULE_IDS: '@ZaDark:UPDATE_ENABLED_BLOCKING_RULE_IDS'
 }
 
 $(ratingElName).attr('href', window.zadark.utils.getRatingURL(window.zadark.browser.name))
-$(feedbackElName).attr('href', window.zadark.utils.getFeedbackURL(window.zadark.browser.name))
 $(versionElName).html(`Phiên bản ${manifestData.version}`)
 
 const iconQuestionSVG = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="14" height="14"><path d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z" fill="currentColor" /></svg>'
@@ -44,56 +40,39 @@ tippy('[data-tippy-content]', {
 // Init popup theme
 window.zadark.utils.refreshPageTheme()
 
-window.zadark.browser.getExtensionSettings().then(({ theme, font, fontSize, enabledHideLatestMessage, enabledHideThreadChatMessage }) => {
+window.zadark.browser.getExtensionSettings().then(({ theme, font, fontSize, enabledHideThreadChatMessage }) => {
   $(selectThemeElName).filter(`[value="${theme}"]`).attr('checked', true)
   $(selectFontElName).val(font)
   $(selectFontSizeElName).val(fontSize)
-  $(switchHideLatestMessageElName).prop('checked', enabledHideLatestMessage)
   $(switchHideThreadChatMessageElName).prop('checked', enabledHideThreadChatMessage)
 })
 
 $(selectThemeElName).on('change', async function () {
   const theme = $(this).val()
-
   await window.zadark.browser.saveExtensionSettings({ theme })
-
   // Set popup theme
   window.zadark.utils.refreshPageTheme()
-
   // Set theme for all Zalo tabs
   window.zadark.browser.sendMessage2ZaloTabs(MSG_ACTIONS.CHANGE_THEME, { theme })
 })
 
 $(selectFontElName).on('change', async function () {
   const font = $(this).val()
-
   await window.zadark.browser.saveExtensionSettings({ font })
-
   // Set font for all Zalo tabs
   window.zadark.browser.sendMessage2ZaloTabs(MSG_ACTIONS.CHANGE_FONT, { font })
 })
 
 $(selectFontSizeElName).on('change', async function () {
   const fontSize = $(this).val()
-
   await window.zadark.browser.saveExtensionSettings({ fontSize })
-
   // Set fontSize for all Zalo tabs
   window.zadark.browser.sendMessage2ZaloTabs(MSG_ACTIONS.CHANGE_FONT_SIZE, { fontSize })
-})
-
-$(switchHideLatestMessageElName).on('change', async function () {
-  const enabledHideLatestMessage = $(this).is(':checked')
-  await window.zadark.browser.saveExtensionSettings({ enabledHideLatestMessage })
-
-  // Set enabledHideLatestMessage for all Zalo tabs
-  window.zadark.browser.sendMessage2ZaloTabs(MSG_ACTIONS.CHANGE_HIDE_LATEST_MESSAGE, { enabledHideLatestMessage })
 })
 
 $(switchHideThreadChatMessageElName).on('change', async function () {
   const enabledHideThreadChatMessage = $(this).is(':checked')
   await window.zadark.browser.saveExtensionSettings({ enabledHideThreadChatMessage })
-
   // Set enabledHideThreadChatMessage for all Zalo tabs
   window.zadark.browser.sendMessage2ZaloTabs(MSG_ACTIONS.CHANGE_HIDE_THREAD_CHAT_MESSAGE, { enabledHideThreadChatMessage })
 })

--- a/src/web/js/utils.js
+++ b/src/web/js/utils.js
@@ -53,18 +53,11 @@
         theme,
         font,
         fontSize,
-        enabledHideLatestMessage,
         enabledHideThreadChatMessage
       }) => {
         this.setPageTheme(theme)
         this.setFontAttr(font)
         this.setFontSizeAttr(fontSize)
-
-        if (enabledHideLatestMessage) {
-          document.body.classList.add('zadark-prv--latest-message')
-        } else {
-          document.body.classList.remove('zadark-prv--latest-message')
-        }
 
         if (enabledHideThreadChatMessage) {
           document.body.classList.add('zadark-prv--thread-chat-message')
@@ -115,10 +108,6 @@
           return 'https://chrome.google.com/webstore/detail/llfhpkkeljlgnjgkholeppfnepmjppob/reviews'
         }
       }
-    },
-
-    getFeedbackURL: (platformName = 'Chrome') => {
-      return `https://docs.google.com/forms/d/e/1FAIpQLSfy8AXwBO-myPPkbXboq5ubeMa0MCMWJTl0Ke66qCyCAiWG9g/viewform?usp=pp_url&entry.454875478=${platformName}`
     }
   }
 

--- a/src/web/js/zadark.js
+++ b/src/web/js/zadark.js
@@ -11,7 +11,6 @@ const MSG_ACTIONS = {
   CHANGE_THEME: '@ZaDark:CHANGE_THEME',
   CHANGE_FONT: '@ZaDark:CHANGE_FONT',
   CHANGE_FONT_SIZE: '@ZaDark:CHANGE_FONT_SIZE',
-  CHANGE_HIDE_LATEST_MESSAGE: '@ZaDark:CHANGE_HIDE_LATEST_MESSAGE',
   CHANGE_HIDE_THREAD_CHAT_MESSAGE: '@ZaDark:CHANGE_HIDE_THREAD_CHAT_MESSAGE',
   GET_ENABLED_BLOCKING_RULE_IDS: '@ZaDark:GET_ENABLED_BLOCKING_RULE_IDS',
   UPDATE_ENABLED_BLOCKING_RULE_IDS: '@ZaDark:UPDATE_ENABLED_BLOCKING_RULE_IDS'
@@ -49,12 +48,6 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     sendResponse({ received: true })
   }
 
-  if (message.action === MSG_ACTIONS.CHANGE_HIDE_LATEST_MESSAGE) {
-    window.zadark.utils.refreshPageSettings()
-    setSwitchHideLatestMessage(message.payload.enabledHideLatestMessage)
-    sendResponse({ received: true })
-  }
-
   if (message.action === MSG_ACTIONS.CHANGE_HIDE_THREAD_CHAT_MESSAGE) {
     window.zadark.utils.refreshPageSettings()
     setSwitchHideThreadChatMessage(message.payload.enabledHideThreadChatMessage)
@@ -66,7 +59,6 @@ const selectThemeElName = '#js-select-theme input:radio[name="theme"]'
 const selectFontElName = '#js-select-font'
 const selectFontSizeElName = '#js-select-font-size'
 
-const switchHideLatestMessageElName = '#js-switch-hide-latest-message'
 const switchHideThreadChatMessageElName = '#js-switch-hide-thread-chat-message'
 const switchBlockTypingElName = '#js-switch-block-typing'
 const switchBlockSeenElName = '#js-switch-block-seen'
@@ -86,10 +78,6 @@ const setSelectFont = (font) => {
 
 const setSelectFontSize = (fontSize) => {
   $(selectFontSizeElName).val(fontSize)
-}
-
-const setSwitchHideLatestMessage = (enabled) => {
-  $(switchHideLatestMessageElName).prop('checked', enabled)
 }
 
 const setSwitchHideThreadChatMessage = (enabled) => {
@@ -112,12 +100,6 @@ async function handleSelectFontChange () {
 async function handleSelectFontSizeChange () {
   const fontSize = $(this).val()
   await window.zadark.browser.saveExtensionSettings({ fontSize })
-  window.zadark.utils.refreshPageSettings()
-}
-
-async function handleHideLastestMessageChange () {
-  const enabledHideLatestMessage = $(this).is(':checked')
-  await window.zadark.browser.saveExtensionSettings({ enabledHideLatestMessage })
   window.zadark.utils.refreshPageSettings()
 }
 
@@ -146,7 +128,7 @@ const iconQuestionSVG = `
 `
 
 const zadarkButtonHTML = `
-  <div id="div_Main_TabZaDark" class="clickable leftbar-tab flx flx-col flx-al-c flx-center rel" data-id="div_Main_TabZaDark" data-translate-title="STR_MENU_ZADARK" title="ZaDark">
+  <div id="div_Main_TabZaDark" class="clickable leftbar-tab flx flx-col flx-al-c flx-center rel" data-id="div_Main_TabZaDark" data-translate-title="STR_MENU_ZADARK" title="ZaDark Settings">
     <svg width="24" height="24" viewBox="0 0 336 336" fill="none" xmlns="http://www.w3.org/2000/svg">
       <path d="M0.000806072 167.484C0.284527 74.7006 75.3948 -0.284182 167.764 0.000809684C181.016 0.0416946 193.907 1.63028 206.268 4.59743C208.09 5.03469 209.381 6.66172 209.399 8.5429C209.417 10.4241 208.158 12.076 206.345 12.5488C151.203 26.9302 110.418 77.1876 110.235 137.092C110.017 208.377 167.37 266.343 238.337 266.562C263.059 266.638 286.161 259.7 305.789 247.614C307.386 246.631 309.444 246.867 310.78 248.185C312.116 249.504 312.386 251.568 311.435 253.188C282.267 302.895 228.343 336.189 166.737 335.999C74.3674 335.714 -0.282915 260.267 0.000806072 167.484Z" fill="currentColor"/>
       <path d="M284.255 176.183C286.752 166.785 288 159.507 288 154.35C288 152.974 286.315 151.37 282.944 149.536C279.698 147.702 277.513 146.785 276.389 146.785C275.391 146.785 274.891 146.9 274.891 147.129C273.768 150.109 271.458 154.063 267.963 158.991C264.467 163.92 261.72 167.186 259.723 168.791C256.477 170.625 249.61 171.542 239.124 171.542C228.762 171.542 223.581 171.14 223.581 170.338C223.581 167.817 231.633 156.069 247.738 135.095C263.968 114.12 275.953 99.6218 283.693 91.5989C284.692 90.682 285.191 90.0516 285.191 89.7077C285.191 86.2693 284.504 83.1748 283.131 80.4241C281.883 77.6733 280.759 75.8968 279.76 75.0946C277.513 74.4069 269.398 74.063 255.416 74.063C241.558 74.063 229.011 74.808 217.775 76.298C217.526 76.298 215.591 75.6103 211.97 74.235C208.35 72.745 204.792 72 201.296 72C200.797 72 199.735 74.1777 198.112 78.533C196.614 82.8882 195.179 87.8166 193.805 93.3181C192.557 98.8195 191.933 102.946 191.933 105.696C191.933 106.613 193.493 107.931 196.614 109.65C199.86 111.37 202.357 112.229 204.105 112.229L206.539 108.447C211.533 100.424 214.904 96.1261 216.652 95.553C220.397 93.8338 226.889 92.9742 236.127 92.9742C245.491 92.9742 250.172 93.318 250.172 94.0057C250.172 95.2665 245.553 101.628 236.315 113.089C227.076 124.436 217.213 136.585 206.727 149.536C196.365 162.487 190.185 170.911 188.187 174.808C188.062 175.266 188 176.47 188 178.418C188 180.367 188.687 182.946 190.06 186.155C191.558 189.364 192.931 190.968 194.18 190.968L252.794 189.421C256.914 189.421 259.473 189.479 260.472 189.593L263.281 190.281C269.149 191.427 273.456 192 276.202 192C277.576 192 278.449 191.828 278.824 191.484C279.948 190.567 281.758 185.467 284.255 176.183Z" fill="currentColor"/>
@@ -169,7 +151,7 @@ const popupHeaderHTML = `
       </span>
 
       <span class="zadark-popup__header__menu-item zadark-popup__header__menu-divider">
-        <a href="${window.zadark.utils.getFeedbackURL(window.zadark.browser.name)}" title="Phản hồi" target="_blank">Phản hồi</a>
+        <a href="https://zadark.canny.io" title="Phản hồi" target="_blank">Phản hồi</a>
       </span>
 
       <span class="zadark-popup__header__menu-item">
@@ -225,7 +207,7 @@ const popupMainHTML = `
         </div>
 
         <div class="select-font">
-          <label class="select-font__label">Thay đổi cỡ chữ trong Trò chuyện</label>
+          <label class="select-font__label">Thay đổi cỡ chữ của tin nhắn</label>
 
           <select id="js-select-font-size" class="zadark-select zadark-select--text-right">
             <option value="small">Nhỏ</option>
@@ -244,20 +226,9 @@ const popupMainHTML = `
         <div class="zadark-panel__body">
           <div class="zadark-switch__list">
             <div class="zadark-switch">
-              <label class="zadark-switch__label zadark-switch__label--helper" for="js-switch-hide-latest-message">
-                Ẩn&nbsp;<strong>Tin nhắn gần nhất</strong>&nbsp;trong Danh sách trò chuyện
-                <span class="zadark-switch__label--helper-icon" data-tippy-content="<p>Tin nhắn gần nhất trong Danh sách trò chuyện (bên trái) sẽ được ẩn để hạn chế người khác nhìn trộm tin nhắn.</p><p>Để xem nội dung, bạn di chuyển chuột hoặc nhấn vào Cuộc trò chuyện.</p>"></span>
-              </label>
-              <label class="zadark-switch__checkbox">
-                <input class="zadark-switch__input" type="checkbox" id="js-switch-hide-latest-message">
-                <span class="zadark-switch__slider"></span>
-              </label>
-            </div>
-
-            <div class="zadark-switch">
               <label class="zadark-switch__label zadark-switch__label--helper" for="js-switch-hide-thread-chat-message">
-                Ẩn&nbsp;<strong>Tin nhắn</strong>&nbsp;trong Trò chuyện
-                <span class="zadark-switch__label--helper-icon" data-tippy-content="<p>Tin nhắn trong Trò chuyện sẽ được làm mờ để hạn chế người khác nhìn trộm tin nhắn.</p><p>Để xem nội dung, bạn di chuyển chuột vào Vùng hiển thị tin nhắn. Di chuyển chuột khỏi Vùng hiển thị tin nhắn để ẩn tin nhắn.</p>"></span>
+                Chống nhìn trộm tin nhắn
+                <span class="zadark-switch__label--helper-icon" data-tippy-content="<p>Danh sách trò chuyện sẽ ẩn đi các tin nhắn gần nhất để ngăn người khác xem trộm. Để xem nội dung tin nhắn, bạn chỉ cần di chuột vào cuộc trò chuyện tương ứng.</p><p>Tin nhắn trong trò chuyện cũng sẽ được làm mờ để bảo vệ quyền riêng tư của bạn. Để xem nội dung tin nhắn, hãy di chuột vào vùng hiển thị tin nhắn. Khi bạn di chuột ra khỏi vùng này, tin nhắn sẽ được ẩn đi.</p>"></span>
               </label>
               <label class="zadark-switch__checkbox">
                 <input class="zadark-switch__input" type="checkbox" id="js-switch-hide-thread-chat-message">
@@ -266,7 +237,7 @@ const popupMainHTML = `
             </div>
 
             <div class="zadark-switch">
-              <label class="zadark-switch__label" for="js-switch-block-typing">Ẩn trạng thái <strong>Đang soạn tin nhắn ...</strong></label>
+              <label class="zadark-switch__label" for="js-switch-block-typing">Ẩn trạng thái <strong>Đang soạn tin (Typing) ...</strong></label>
               <label class="zadark-switch__checkbox">
                 <input class="zadark-switch__input" type="checkbox" id="js-switch-block-typing">
                 <span class="zadark-switch__slider"></span>
@@ -274,7 +245,7 @@ const popupMainHTML = `
             </div>
 
             <div class="zadark-switch">
-              <label class="zadark-switch__label" for="js-switch-block-delivered">Ẩn trạng thái <strong>Đã nhận</strong> tin nhắn</label>
+              <label class="zadark-switch__label" for="js-switch-block-delivered">Ẩn trạng thái <strong>Đã nhận (Received)</strong></label>
               <label class="zadark-switch__checkbox">
                 <input class="zadark-switch__input" type="checkbox" id="js-switch-block-delivered">
                 <span class="zadark-switch__slider"></span>
@@ -282,7 +253,7 @@ const popupMainHTML = `
             </div>
 
             <div class="zadark-switch">
-              <label class="zadark-switch__label" for="js-switch-block-seen">Ẩn trạng thái <strong>Đã xem</strong> tin nhắn</label>
+              <label class="zadark-switch__label" for="js-switch-block-seen">Ẩn trạng thái <strong>Đã xem (Seen)</strong></label>
               <label class="zadark-switch__checkbox">
                 <input class="zadark-switch__input" type="checkbox" id="js-switch-block-seen">
                 <span class="zadark-switch__slider"></span>
@@ -339,14 +310,12 @@ const loadPopupState = async () => {
     theme,
     font,
     fontSize,
-    enabledHideLatestMessage,
     enabledHideThreadChatMessage
   } = await window.zadark.browser.getExtensionSettings()
 
   setSelectTheme(theme)
   setSelectFont(font)
   setSelectFontSize(fontSize)
-  setSwitchHideLatestMessage(enabledHideLatestMessage)
   setSwitchHideThreadChatMessage(enabledHideThreadChatMessage)
 
   const isSupportBlocking = window.zadark.utils.getIsSupportBlocking()
@@ -431,7 +400,6 @@ const loadZaDarkPopup = () => {
   $(selectFontElName).on('change', handleSelectFontChange)
   $(selectFontSizeElName).on('change', handleSelectFontSizeChange)
 
-  $(switchHideLatestMessageElName).on('change', handleHideLastestMessageChange)
   $(switchHideThreadChatMessageElName).on('change', handleHideThreadChatMessageChange)
 
   $(switchBlockTypingElName).on('change', handleBlockingRuleChange(switchBlockTypingElName, 'rules_block_typing'))

--- a/src/web/popup.html
+++ b/src/web/popup.html
@@ -27,7 +27,7 @@
       </span>
 
       <span class="zadark-popup__header__menu-item zadark-popup__header__menu-divider">
-        <a href="#feedback" id="js-ext-feedback" title="Phản hồi" target="_blank">Phản hồi</a>
+        <a href="https://zadark.canny.io" title="Phản hồi" target="_blank">Phản hồi</a>
       </span>
 
       <span class="zadark-popup__header__menu-item">
@@ -81,7 +81,7 @@
         </div>
 
         <div class="select-font">
-          <label class="select-font__label">Thay đổi cỡ chữ trong Trò chuyện</label>
+          <label class="select-font__label">Thay đổi cỡ chữ của tin nhắn</label>
 
           <select id="js-select-font-size" class="zadark-select zadark-select--text-right">
             <option value="small">Nhỏ</option>
@@ -100,20 +100,9 @@
         <div class="zadark-panel__body">
           <div class="zadark-switch__list">
             <div class="zadark-switch">
-              <label class="zadark-switch__label zadark-switch__label--helper" for="js-switch-hide-latest-message">
-                Ẩn&nbsp;<strong>Tin nhắn gần nhất</strong>&nbsp;trong Danh sách trò chuyện
-                <span class="zadark-switch__label--helper-icon" data-tippy-content="<p>Tin nhắn gần nhất trong Danh sách trò chuyện (bên trái) sẽ được ẩn để hạn chế người khác nhìn trộm tin nhắn.</p><p>Để xem nội dung, bạn di chuyển chuột hoặc nhấn vào Cuộc trò chuyện.</p>"></span>
-              </label>
-              <label class="zadark-switch__checkbox">
-                <input class="zadark-switch__input" type="checkbox" id="js-switch-hide-latest-message">
-                <span class="zadark-switch__slider"></span>
-              </label>
-            </div>
-
-            <div class="zadark-switch">
               <label class="zadark-switch__label zadark-switch__label--helper" for="js-switch-hide-thread-chat-message">
-                Ẩn&nbsp;<strong>Tin nhắn</strong>&nbsp;trong Cuộc trò chuyện
-                <span class="zadark-switch__label--helper-icon" data-tippy-content="<p>Tin nhắn trong Cuộc trò chuyện sẽ được làm mờ để hạn chế người khác nhìn trộm tin nhắn.</p><p>Để xem nội dung, bạn di chuyển chuột vào Vùng hiển thị tin nhắn. Di chuyển chuột khỏi Vùng hiển thị tin nhắn để ẩn tin nhắn.</p>"></span>
+                Chống nhìn trộm tin nhắn
+                <span class="zadark-switch__label--helper-icon" data-tippy-content="<p>Danh sách trò chuyện sẽ ẩn đi các tin nhắn gần nhất để ngăn người khác xem trộm. Để xem nội dung tin nhắn, bạn chỉ cần di chuột vào cuộc trò chuyện tương ứng.</p><p>Tin nhắn trong trò chuyện cũng sẽ được làm mờ để bảo vệ quyền riêng tư của bạn. Để xem nội dung tin nhắn, hãy di chuột vào vùng hiển thị tin nhắn. Khi bạn di chuột ra khỏi vùng này, tin nhắn sẽ được ẩn đi.</p>"></span>
               </label>
               <label class="zadark-switch__checkbox">
                 <input class="zadark-switch__input" type="checkbox" id="js-switch-hide-thread-chat-message">
@@ -122,7 +111,7 @@
             </div>
 
             <div class="zadark-switch">
-              <label class="zadark-switch__label" for="js-switch-block-typing">Ẩn trạng thái <strong>Đang soạn tin nhắn ...</strong></label>
+              <label class="zadark-switch__label" for="js-switch-block-typing">Ẩn trạng thái <strong>Đang soạn tin (Typing) ...</strong></label>
               <label class="zadark-switch__checkbox">
                 <input class="zadark-switch__input" type="checkbox" id="js-switch-block-typing">
                 <span class="zadark-switch__slider"></span>
@@ -130,7 +119,7 @@
             </div>
 
             <div class="zadark-switch">
-              <label class="zadark-switch__label" for="js-switch-block-delivered">Ẩn trạng thái <strong>Đã nhận</strong> tin nhắn</label>
+              <label class="zadark-switch__label" for="js-switch-block-delivered">Ẩn trạng thái <strong>Đã nhận (Received)</strong></label>
               <label class="zadark-switch__checkbox">
                 <input class="zadark-switch__input" type="checkbox" id="js-switch-block-delivered">
                 <span class="zadark-switch__slider"></span>
@@ -138,7 +127,7 @@
             </div>
 
             <div class="zadark-switch">
-              <label class="zadark-switch__label" for="js-switch-block-seen">Ẩn trạng thái <strong>Đã xem</strong> tin nhắn</label>
+              <label class="zadark-switch__label" for="js-switch-block-seen">Ẩn trạng thái <strong>Đã xem (Seen)</strong></label>
               <label class="zadark-switch__checkbox">
                 <input class="zadark-switch__input" type="checkbox" id="js-switch-block-seen">
                 <span class="zadark-switch__slider"></span>

--- a/src/web/vendor/chrome/browser.js
+++ b/src/web/vendor/chrome/browser.js
@@ -26,7 +26,6 @@
           theme: 'dark',
           font: 'open-sans',
           fontSize: 'medium',
-          enabledHideLatestMessage: false,
           enabledHideThreadChatMessage: false,
           enabledBlockTyping: false,
           enabledBlockDelivered: false,

--- a/src/web/vendor/chrome/manifest.json
+++ b/src/web/vendor/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ZaDark – Zalo Dark Mode",
-  "version": "8.15",
+  "version": "8.16",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "Quaric",

--- a/src/web/vendor/edge/browser.js
+++ b/src/web/vendor/edge/browser.js
@@ -26,7 +26,6 @@
           theme: 'dark',
           font: 'open-sans',
           fontSize: 'medium',
-          enabledHideLatestMessage: false,
           enabledHideThreadChatMessage: false,
           enabledBlockTyping: false,
           enabledBlockDelivered: false,

--- a/src/web/vendor/edge/manifest.json
+++ b/src/web/vendor/edge/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ZaDark – Zalo Dark Mode",
-  "version": "8.15",
+  "version": "8.16",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "Quaric",

--- a/src/web/vendor/firefox/browser.js
+++ b/src/web/vendor/firefox/browser.js
@@ -26,7 +26,6 @@
           theme: 'dark',
           font: 'open-sans',
           fontSize: 'medium',
-          enabledHideLatestMessage: false,
           enabledHideThreadChatMessage: false,
           knownVersion: ''
         }, (items) => {

--- a/src/web/vendor/firefox/manifest.json
+++ b/src/web/vendor/firefox/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "ZaDark – Zalo Dark Mode",
-  "version": "8.15",
+  "version": "8.16",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "Quaric",

--- a/src/web/vendor/opera/browser.js
+++ b/src/web/vendor/opera/browser.js
@@ -26,7 +26,6 @@
           theme: 'dark',
           font: 'open-sans',
           fontSize: 'medium',
-          enabledHideLatestMessage: false,
           enabledHideThreadChatMessage: false,
           enabledBlockTyping: false,
           enabledBlockDelivered: false,

--- a/src/web/vendor/opera/manifest.json
+++ b/src/web/vendor/opera/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ZaDark – Zalo Dark Mode",
-  "version": "8.15",
+  "version": "8.16",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "Quaric",

--- a/src/web/vendor/safari/browser.js
+++ b/src/web/vendor/safari/browser.js
@@ -26,7 +26,6 @@
           theme: 'dark',
           font: 'open-sans',
           fontSize: 'medium',
-          enabledHideLatestMessage: false,
           enabledHideThreadChatMessage: false,
           enabledBlockTyping: false,
           enabledBlockDelivered: false,

--- a/src/web/vendor/safari/manifest.json
+++ b/src/web/vendor/safari/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "ZaDark – Zalo Dark Mode",
-  "version": "8.15",
+  "version": "8.16",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "Quaric",

--- a/tools/macos/notarize.sh
+++ b/tools/macos/notarize.sh
@@ -31,10 +31,10 @@ source .env
 version=$(grep -o '"version": *"[^"]*"' src/pc/package.json | awk -F'"' '{print $4}')
 
 # Set the package file path based on the version number
-pkgFilePath=dist/macos/ZaDark-macOS-${version//./_}.pkg
+pkgFilePath=dist/macos/ZaDark\ ${version}.pkg
 
 echo "[Prepare]"
-echo $pkgFilePath
+echo "$pkgFilePath"
 
 echo ""
 echo "[Notarize]"

--- a/tools/macos/pkgbuild.sh
+++ b/tools/macos/pkgbuild.sh
@@ -30,25 +30,25 @@ tmpPath=.zadark
 version=$(grep -o '"version": *"[^"]*"' src/pc/package.json | awk -F'"' '{print $4}')
 
 # Set original file path and package file path based on the version number
-originalFilePath=dist/macos/ZaDark-macOS-${version//./_}
-pkgFilePath=dist/macos/ZaDark-macOS-${version//./_}.pkg
+originalFilePath=dist/macos/ZaDark\ ${version}\ exec
+pkgFilePath=dist/macos/ZaDark\ ${version}.pkg
 
 echo "[Prepare]"
 
 # Clean up the temporary path
-rm -rf $tmpPath
+rm -rf "$tmpPath"
 
 # Create the temporary path
-mkdir $tmpPath
+mkdir "$tmpPath"
 
 # Copy the original file to the temporary path
-ditto $originalFilePath $tmpPath/ZaDark
+ditto "$originalFilePath" "$tmpPath/ZaDark"
 
 echo ""
 echo "[Sign the executable]"
 
 # Sign the ZaDark file in the temporary path
-codesign --deep --force --options=runtime --entitlements tools/macos/assets/entitlements.plist --sign "$hash_dev_id_application" --timestamp $tmpPath/ZaDark
+codesign --deep --force --options=runtime --entitlements tools/macos/assets/entitlements.plist --sign "$hash_dev_id_application" --timestamp "$tmpPath/ZaDark"
 
 echo ""
 echo "[Package as a pkg for installation]"
@@ -65,7 +65,7 @@ pkgbuild \
 
 echo ""
 echo "[Done]"
-echo $pkgFilePath
+echo "$pkgFilePath"
 
 # Clean up the temporary path
-rm -rf $tmpPath
+rm -rf "$tmpPath"

--- a/tools/macos/staple.sh
+++ b/tools/macos/staple.sh
@@ -10,10 +10,10 @@ source .env
 version=$(grep -o '"version": *"[^"]*"' src/pc/package.json | awk -F'"' '{print $4}')
 
 # Construct the file path of the package (pkg) file using the version number
-pkgFilePath=dist/macos/ZaDark-macOS-${version//./_}.pkg
+pkgFilePath=dist/macos/ZaDark\ ${version}.pkg
 
 echo "[Prepare]"
-echo $pkgFilePath
+echo "$pkgFilePath"
 
 echo ""
 echo "[Staple notarization to pkg]"
@@ -23,4 +23,4 @@ xcrun stapler staple "$pkgFilePath"
 
 echo ""
 echo "[Done]"
-echo $pkgFilePath
+echo "$pkgFilePath"


### PR DESCRIPTION
## ZaDark 23.6.1
> PC 8.4 && Web 8.16

### Added
- **[Core]** Bổ sung cho chức năng "Thay đổi cỡ chữ của tin nhắn" : Áp dụng cho tin nhắn có hình ảnh

### Changed
- **[ZaDark Settings]**
  - Giảm sáng cho biểu tượng màu trắng của công tắc (switch)
  - Thay đổi địa chỉ Phản hồi (sử dụng Canny thay Google Forms)
  - Hợp nhất tính năng "Ẩn Tin nhắn gần nhất ở Danh sách trò chuyện" và "Ẩn Tin nhắn trong Cuộc trò chuyện" thành "Chống nhìn trộm tin nhắn" (Rê chuột vào dấu chấm hỏi để xem giải thích chi tiết)
  - Cập nhật một số chi tiết nhỏ khác
- **[Source code]**
  - Thay đổi flow thoát Zalo PC
  - Thay đổi cấu trúc đặt tên cho tập tin cài đặt ngắn gọn hơn