### PR TITLE
Feature/23.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@
 > PC 9.1 && Web 9.1
 
 ### Changed
-- Hỗ trợ Dark Mode nhãn trạng thái "Đã nhận", "Đã gửi"
-- Hỗ trợ Ẩn ảnh đại diện ở nhãn trạng thái "Đã xem"
+- Hỗ trợ Dark Mode nhãn trạng thái "Đã nhận", "Đã gửi" (`.bubble-message-status`)
+- Hỗ trợ Ẩn ảnh đại diện ở nhãn trạng thái "Đã xem" (`.seen-msg-stt`)
+- Sửa lỗi Dark Mode nhãn tin nhắn chưa đọc (`.conv-action__unread-v2 .conv-unread`)
 
 ## ZaDark 23.6.3
 > PC 9.0 && Web 9.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## ZaDark 23.6.4
+> PC 9.1 && Web 9.1
+
+### Changed
+- Hỗ trợ Dark Mode nhãn trạng thái "Đã nhận", "Đã gửi"
+- Hỗ trợ Ẩn ảnh đại diện ở nhãn trạng thái "Đã xem"
+
 ## ZaDark 23.6.3
 > PC 9.0 && Web 9.0
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadark",
   "description": "Dark Mode tốt nhất cho Zalo",
-  "version": "23.6.3",
+  "version": "23.6.4",
   "repository": "https://github.com/quaric/zadark.git",
   "author": {
     "name": "Quaric",

--- a/src/core/scss/_zadark-prv.scss
+++ b/src/core/scss/_zadark-prv.scss
@@ -263,6 +263,7 @@
   .conv-item,
   .chat-item:not(.me),
   .threadChat__avatar,
+  .seen-msg-stt,
   div[keys="avt-list-conv-media_box"] {
     --zadark-avatar-color: var(--N30);
     --zadark-avatar-bg: var(--N10);
@@ -292,6 +293,9 @@
         content: "\e900";
       }
 
+      &.zavatar-xxs::after {
+        font-size: 0.5rem;
+      }
       &.zavatar-m::after {
         font-size: 1rem;
       }

--- a/src/core/scss/zadark.scss
+++ b/src/core/scss/zadark.scss
@@ -1148,8 +1148,11 @@ html[data-zadark-theme="dark"] {
       background-color: var(--WA100);
     }
 
-    .conv-action__unread .conv-unread {
-      color: #fff !important;
+    .conv-action__unread,
+    .conv-action__unread-v2 {
+      .conv-unread {
+        color: #fff !important;
+      }
     }
 
     .conv-item {

--- a/src/core/scss/zadark.scss
+++ b/src/core/scss/zadark.scss
@@ -1988,6 +1988,12 @@ html[data-zadark-theme="dark"] {
     .text-color-menu-container .text-color-menu[style*="rgb(5, 10, 25)"] {
       background-color: var(--text-primary) !important;
     }
+
+    .bubble-message-status {
+      padding: 0 8px 0 6px;
+      background-color: var(--NG10);
+      color: var(--text-secondary);
+    }
   }
 }
 

--- a/src/pc/package.json
+++ b/src/pc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadark-pc",
   "description": "Dark Mode tốt nhất cho Zalo",
-  "version": "9.0",
+  "version": "9.1",
   "main": "index.js",
   "repository": "https://github.com/quaric/zadark.git",
   "author": {

--- a/src/web/vendor/chrome/manifest.json
+++ b/src/web/vendor/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ZaDark – Zalo Dark Mode",
-  "version": "9.0",
+  "version": "9.1",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "Quaric",

--- a/src/web/vendor/edge/manifest.json
+++ b/src/web/vendor/edge/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ZaDark – Zalo Dark Mode",
-  "version": "9.0",
+  "version": "9.1",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "Quaric",

--- a/src/web/vendor/firefox/manifest.json
+++ b/src/web/vendor/firefox/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "ZaDark – Zalo Dark Mode",
-  "version": "9.0",
+  "version": "9.1",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "Quaric",

--- a/src/web/vendor/opera/manifest.json
+++ b/src/web/vendor/opera/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ZaDark – Zalo Dark Mode",
-  "version": "9.0",
+  "version": "9.1",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "Quaric",

--- a/src/web/vendor/safari/manifest.json
+++ b/src/web/vendor/safari/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "ZaDark – Zalo Dark Mode",
-  "version": "9.0",
+  "version": "9.1",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "Quaric",


### PR DESCRIPTION
## ZaDark 23.6.4
> PC 9.1 && Web 9.1

### Changed
- Hỗ trợ Dark Mode nhãn trạng thái "Đã nhận", "Đã gửi" (`.bubble-message-status`)
- Hỗ trợ Ẩn ảnh đại diện ở nhãn trạng thái "Đã xem" (`.seen-msg-stt`)
- Sửa lỗi Dark Mode nhãn tin nhắn chưa đọc (`.conv-action__unread-v2 .conv-unread`)