### PR TITLE
Feature/23.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## ZaDark 23.7.3
+> PC 9.4 && Web 9.4
+
+### Fixed
+
+- Sửa lỗi màu nền không thay đổi khi rê chuột/lựa chọn tin nhắn nhanh ([#65](https://github.com/quaric/zadark/issues/65))
+
+#### Windows specific
+- Sửa lỗi phím tắt "Ẩn ảnh đại diện, tên cuộc trò chuyện" bị trùng ([#66](https://github.com/quaric/zadark/issues/66))
+
 ## ZaDark 23.7.2
 > PC 9.3 && Web 9.3
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadark",
   "description": "Dark Mode tốt nhất cho Zalo",
-  "version": "23.7.2",
+  "version": "23.7.3",
   "repository": "https://github.com/quaric/zadark.git",
   "author": {
     "name": "Quaric",

--- a/src/core/scss/zadark.scss
+++ b/src/core/scss/zadark.scss
@@ -1129,6 +1129,16 @@ html[data-zadark-theme="dark"] {
     }
     .qri {
       background-color: var(--WA100);
+
+      &.active,
+      &.hover:hover {
+        background-color: var(--layer-background-hover);
+        cursor: pointer;
+      }
+    }
+    .qri__left > .qri__keyword {
+      background-color: var(--button-tertiary-primary-text);
+      color: #fff;
     }
 
     .conv-action__unread,
@@ -1985,11 +1995,6 @@ html[data-zadark-theme="dark"] {
       padding: 0 8px;
       background-color: var(--NG10);
       color: var(--text-secondary);
-    }
-
-    .qri__left > .qri__keyword {
-      background-color: var(--button-tertiary-primary-text);
-      color: #fff;
     }
 
     .chat-info-general__section__content {

--- a/src/pc/assets/js/zadark.js
+++ b/src/pc/assets/js/zadark.js
@@ -707,7 +707,7 @@
                   <i class="zadark-icon zadark-icon--question" data-tippy-content='<p>Để xem Tên cuộc trò chuyện, bạn di chuyển chuột vào "<strong>Tên cuộc trò chuyện</strong>" cần xem.</p>'></i>
                 </label>
                 <span class="zadark-switch__hotkeys">
-                  <span class="zadark-hotkeys" data-keys-win="Ctrl+3" data-keys-mac="⌘3"></span>
+                  <span class="zadark-hotkeys" data-keys-win="Ctrl+7" data-keys-mac="⌘7"></span>
                 </span>
                 <label class="zadark-switch__checkbox">
                   <input class="zadark-switch__input" type="checkbox" id="js-switch-hide-conv-name">

--- a/src/pc/package.json
+++ b/src/pc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadark-pc",
   "description": "Dark Mode tốt nhất cho Zalo",
-  "version": "9.3",
+  "version": "9.4",
   "main": "index.js",
   "repository": "https://github.com/quaric/zadark.git",
   "author": {

--- a/src/web/vendor/chrome/manifest.json
+++ b/src/web/vendor/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ZaDark – Zalo Dark Mode",
-  "version": "9.3",
+  "version": "9.4",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "Quaric",

--- a/src/web/vendor/edge/manifest.json
+++ b/src/web/vendor/edge/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ZaDark – Zalo Dark Mode",
-  "version": "9.3",
+  "version": "9.4",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "Quaric",

--- a/src/web/vendor/firefox/manifest.json
+++ b/src/web/vendor/firefox/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "ZaDark – Zalo Dark Mode",
-  "version": "9.3",
+  "version": "9.4",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "Quaric",

--- a/src/web/vendor/opera/manifest.json
+++ b/src/web/vendor/opera/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ZaDark – Zalo Dark Mode",
-  "version": "9.3",
+  "version": "9.4",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "Quaric",

--- a/src/web/vendor/safari/manifest.json
+++ b/src/web/vendor/safari/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "ZaDark – Zalo Dark Mode",
-  "version": "9.3",
+  "version": "9.4",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "Quaric",


### PR DESCRIPTION
## ZaDark 23.7.3
> PC 9.4 && Web 9.4

### Fixed

- Sửa lỗi màu nền không thay đổi khi rê chuột/lựa chọn tin nhắn nhanh ([#65](https://github.com/quaric/zadark/issues/65))

#### Windows specific
- Sửa lỗi phím tắt "Ẩn ảnh đại diện, tên cuộc trò chuyện" bị trùng ([#66](https://github.com/quaric/zadark/issues/66))