### PR TITLE
Feature/23.7.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## ZaDark 23.7.5
+> PC 9.6 && Web 9.6
+
+### Added
+- Bổ sung giải thích (Tooltip) cho chức năng
+  - Ẩn trạng thái Đang soạn tin (Typing) ...
+  - Ẩn trạng thái Đã nhận (Received)
+  - Ẩn trạng thái Đã xem (Seen)
+
+### Changed
+- Thêm màu nền tối (Overlay) giúp người dùng tập trung vào Popup cài đặt ZaDark hơn
+- Bỏ nhãn BETA của cài đặt phông chữ từ Google Fonts
+
 ## ZaDark 23.7.4
 > PC 9.5 && Web 9.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Changed
 - Thêm màu nền tối (Overlay) giúp người dùng tập trung vào Popup cài đặt ZaDark hơn
 - Bỏ nhãn BETA của cài đặt phông chữ từ Google Fonts
+- Ẩn Tin nhắn gần nhất: Giữ lại Nhãn (Label) cuộc trò chuyện
 
 ## ZaDark 23.7.4
 > PC 9.5 && Web 9.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,27 @@
   - Ẩn trạng thái Đang soạn tin (Typing) ...
   - Ẩn trạng thái Đã nhận (Received)
   - Ẩn trạng thái Đã xem (Seen)
+
 #### PC specific
+- Thêm chế độ cài đặt / gỡ cài đặt nhanh **bằng câu lệnh**
+  - Windows
+    - Giải nén file `ZaDark.zip`, mở **Terminal** hoặc **Command Prompt**
+    - Nhập cú pháp cài ZaDark
+      - `"\Thu_Muc_Chua_File_ZaDark\ZaDark 9.6.exe" install` hoặc
+      - `"\Thu_Muc_Chua_File_ZaDark\ZaDark 9.6.exe" in`
+    - Nhập cú pháp gỡ ZaDark
+      - `"\Thu_Muc_Chua_File_ZaDark\ZaDark 9.6.exe" uninstall` hoặc
+      - `"\Thu_Muc_Chua_File_ZaDark\ZaDark 9.6.exe" un`
+    - Ví dụ
+      - `"C:\Users\ncdai\Downloads\ZaDark 9.6\ZaDark 9.6.exe" install`
+  - macOS
+    - Sau khi chạy file `ZaDark.pkg`, mở **Terminal**
+    - Nhập cú pháp cài ZaDark
+      - `/Applications/ZaDark install` hoặc
+      - `/Applications/ZaDark in`
+    - Nhập cú pháp gỡ ZaDark
+      - `/Applications/ZaDark uninstall` hoặc
+      - `/Applications/ZaDark un`
 - Chỉ mở Feedback Unsintall khi người dùng gỡ cài đặt ZaDark lần đầu
 - ZaDark lưu cài đặt vào đường dẫn
   - Windows: `C:\Users\TenNguoiDung\.zadarkconfig`
@@ -22,7 +42,7 @@
 ### Changed
 - Thêm màu nền tối (Overlay) giúp người dùng tập trung vào Popup cài đặt ZaDark hơn
 - Bỏ nhãn BETA của cài đặt phông chữ từ Google Fonts
-- Ẩn Tin nhắn gần nhất: Giữ lại Nhãn (Label) cuộc trò chuyện
+- Ẩn Tin nhắn gần nhất: Giữ lại Nhãn (Label) cuộc trò chuyện ([#57](https://github.com/quaric/zadark/issues/57))
 
 ## ZaDark 23.7.4
 > PC 9.5 && Web 9.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@
   - Ẩn trạng thái Đang soạn tin (Typing) ...
   - Ẩn trạng thái Đã nhận (Received)
   - Ẩn trạng thái Đã xem (Seen)
+#### PC specific
+- Chỉ mở Feedback Unsintall khi người dùng gỡ cài đặt ZaDark lần đầu
+- ZaDark lưu cài đặt vào đường dẫn
+  - Windows: `C:\Users\TenNguoiDung\.zadarkconfig`
+  - macOS: `/Users/TenNguoiDung/.zadarkconfig`
+  - Mục đích
+    - Xác định có phải người dùng gỡ cài đặt lần đầu không
+    - Chuẩn bị cho tính năng Auto Update ZaDark, Auto Reinstall ZaDark
+- **[Windows]** Thay thay đổi đường dẫn chứa chương trình [**fastlist**](https://github.com/MarkTiedemann/fastlist) (Chương trình giúp ZaDark xác định Process ID của Zalo để tắt Zalo trước khi cài đặt)
+  - `C:\Users\TenNguoiDung\.zadark\fastlist-0.3.0.exe`
 
 ### Changed
 - Thêm màu nền tối (Overlay) giúp người dùng tập trung vào Popup cài đặt ZaDark hơn

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadark",
   "description": "Dark Mode tốt nhất cho Zalo",
-  "version": "23.7.4",
+  "version": "23.7.5",
   "repository": "https://github.com/quaric/zadark.git",
   "author": {
     "name": "Quaric",

--- a/src/core/scss/_zadark-prv.scss
+++ b/src/core/scss/_zadark-prv.scss
@@ -1,5 +1,5 @@
 @mixin prv-lastest-message {
-  .conv-item .conv-item-body__main {
+  .conv-item .conv-item-body__main .conv-message {
     position: relative;
 
     &::after {
@@ -16,6 +16,7 @@
       color: var(--text-secondary);
       font-size: 16px;
       letter-spacing: 1px;
+      line-height: normal;
       opacity: 1;
 
       transition: opacity 100ms ease-in-out;
@@ -27,7 +28,7 @@
     }
   }
 
-  .conv-item:hover .conv-item-body__main {
+  .conv-item:hover .conv-item-body__main .conv-message {
     &::after {
       opacity: 0;
     }

--- a/src/core/scss/zadark-popup.scss
+++ b/src/core/scss/zadark-popup.scss
@@ -153,9 +153,6 @@ body:not(.zadark--use-hotkeys) {
 }
 
 #zadark-popup {
-  // position: absolute;
-  // overflow: auto;
-
   font-family: var(--zadark-popup-font-family);
   font-size: 14px;
 

--- a/src/core/scss/zadark.scss
+++ b/src/core/scss/zadark.scss
@@ -503,7 +503,7 @@
   --selection: #0068ff;
   --selection-text: #fff;
 
-  --popper-shadow: 4px 4px 12px var(--BA50);
+  --popper-shadow: var(--BA50) 0px 0px 0px 5000px;
 
   --black: 900;
   --extrabold: 800;
@@ -551,7 +551,7 @@ html[data-zadark-use-font="true"] body.zadark {
 
 html[data-zadark-theme="light"] {
   &:root {
-    --popper-shadow: 0 0 10px 0 var(--BA20);
+    --popper-shadow: var(--BA50) 0px 0px 0px 5000px;
     --prv-sticker-filter: invert(0.5) brightness(2);
   }
 }
@@ -2000,6 +2000,10 @@ html[data-zadark-theme="dark"] {
     .chat-info-general__section__content {
       position: relative;
     }
+
+    #zadark-popup {
+      border: 1px solid var(--border);
+    }
   }
 }
 
@@ -2086,19 +2090,26 @@ body.zadark {
   }
 
   .zadark-popper {
+    position: absolute;
     z-index: 9999;
-    overflow: hidden;
 
     display: none;
     width: 480px;
     max-height: 100%;
 
-    border: 1px solid var(--border);
-    border-radius: 8px;
-    box-shadow: var(--popper-shadow);
-
     &[data-visible] {
       display: block;
+    }
+
+    #zadark-popup {
+      overflow: hidden;
+      margin-bottom: 8px;
+      border-radius: var(--zadark-rounded-base);
+      box-shadow: var(--popper-shadow);
+
+      #js-btn-scroll {
+        bottom: 20px; // 8px + 12px
+      }
     }
   }
 

--- a/src/pc/assets/js/zadark.js
+++ b/src/pc/assets/js/zadark.js
@@ -338,11 +338,11 @@
       const fontFamily = ZaDarkStorage.getFontFamily()
 
       if (!fontFamily) {
-        this.installFontFamily(['Open Sans:400,600:latin,vietnamese'], false)
+        this.installFontFamily(['Open Sans:400,500,600:latin,vietnamese'], false)
         return
       }
 
-      await this.installFontFamily([`${fontFamily}:400,500:latin,vietnamese`, 'Open Sans:400,600:latin,vietnamese'], false)
+      await this.installFontFamily([`${fontFamily}:400,500,600:latin,vietnamese`, 'Open Sans:400,500,600:latin,vietnamese'], false)
       this.setFontFamilyAttr(fontFamily)
     },
 
@@ -693,7 +693,6 @@
           <div class="font-settings font-settings--border-default">
             <label class="font-settings__label">
               Phông chữ từ <a href="https://zadark.quaric.com/blog/use-google-fonts" target="_blank">Google Fonts</a>
-              <span class="zadark-beta"></span>
             </label>
 
             <input id="js-input-font-family" class="zadark-input" placeholder="Mặc định">
@@ -724,7 +723,7 @@
             <div class="zadark-switch">
               <label class="zadark-switch__label zadark-switch__label--helper" for="js-switch-hide-latest-message">
                 Ẩn <strong>Tin nhắn gần nhất</strong>
-                <i class="zadark-icon zadark-icon--question" data-tippy-content='<p>Để xem nội dung tin nhắn, bạn di chuột vào "<strong>Tên cuộc trò chuyện</strong>" cần xem.</p>'></i>
+                <i class="zadark-icon zadark-icon--question" data-tippy-content='Để xem nội dung tin nhắn, bạn di chuột vào<br/>"<strong>Tên cuộc trò chuyện</strong>" cần xem.'></i>
               </label>
               <span class="zadark-switch__hotkeys">
                 <span class="zadark-hotkeys" data-keys-win="Ctrl+1" data-keys-mac="⌘1"></span>
@@ -752,7 +751,7 @@
             <div class="zadark-switch">
               <label class="zadark-switch__label zadark-switch__label--helper" for="js-switch-hide-conv-avatar">
                 Ẩn <strong>Ảnh đại diện</strong> cuộc trò chuyện
-                <i class="zadark-icon zadark-icon--question" data-tippy-content='<p>Để xem Ảnh đại diện, bạn di chuyển chuột vào "<strong>Ảnh đại diện</strong>" cần xem.</p>'></i>
+                <i class="zadark-icon zadark-icon--question" data-tippy-content='Để xem Ảnh đại diện, bạn di chuyển chuột vào<br/>"<strong>Ảnh đại diện</strong>" cần xem.'></i>
               </label>
               <span class="zadark-switch__hotkeys">
                 <span class="zadark-hotkeys" data-keys-win="Ctrl+3" data-keys-mac="⌘3"></span>
@@ -766,7 +765,7 @@
             <div class="zadark-switch zadark-switch--border-default">
               <label class="zadark-switch__label zadark-switch__label--helper" for="js-switch-hide-conv-name">
                 Ẩn <strong>Tên</strong> cuộc trò chuyện
-                <i class="zadark-icon zadark-icon--question" data-tippy-content='<p>Để xem Tên cuộc trò chuyện, bạn di chuyển chuột vào "<strong>Tên cuộc trò chuyện</strong>" cần xem.</p>'></i>
+                <i class="zadark-icon zadark-icon--question" data-tippy-content='Để xem Tên cuộc trò chuyện, bạn di chuyển chuột vào "<strong>Tên cuộc trò chuyện</strong>" cần xem.'></i>
               </label>
               <span class="zadark-switch__hotkeys">
                 <span class="zadark-hotkeys" data-keys-win="Ctrl+7" data-keys-mac="⌘7"></span>
@@ -778,7 +777,10 @@
             </div>
 
             <div class="zadark-switch">
-              <label class="zadark-switch__label" for="js-switch-block-typing">Ẩn trạng thái <strong>Đang soạn tin (Typing) ...</strong></label>
+              <label class="zadark-switch__label zadark-switch__label--helper" for="js-switch-block-typing">
+                Ẩn trạng thái <strong>Đang soạn tin (Typing)</strong>
+                <i class="zadark-icon zadark-icon--question" data-tippy-content='<p style="text-align: justify;">Người khác sẽ không thấy trạng thái <strong>Đang soạn tin (Typing) ...</strong> của bạn, nhưng bạn vẫn thấy trạng thái của họ. Đây là điểm khác biệt giữa cài đặt từ ZaDark và Zalo.</p>'></i>
+              </label>
               <span class="zadark-switch__hotkeys">
                 <span class="zadark-hotkeys" data-keys-win="Ctrl+4" data-keys-mac="⌘4"></span>
               </span>
@@ -789,7 +791,10 @@
             </div>
 
             <div class="zadark-switch">
-              <label class="zadark-switch__label" for="js-switch-block-delivered">Ẩn trạng thái <strong>Đã nhận (Received)</strong></label>
+              <label class="zadark-switch__label zadark-switch__label--helper" for="js-switch-block-delivered">
+                Ẩn trạng thái <strong>Đã nhận (Received)</strong>
+                <i class="zadark-icon zadark-icon--question" data-tippy-content='<p style="text-align: justify;">Người khác sẽ không thấy trạng thái <strong>Đã nhận (Received)</strong> tin nhắn của bạn, nhưng bạn vẫn thấy trạng thái của họ.</p>'></i>
+              </label>
               <span class="zadark-switch__hotkeys">
                 <span class="zadark-hotkeys" data-keys-win="Ctrl+5" data-keys-mac="⌘5"></span>
               </span>
@@ -800,7 +805,10 @@
             </div>
 
             <div class="zadark-switch">
-              <label class="zadark-switch__label" for="js-switch-block-seen">Ẩn trạng thái <strong>Đã xem (Seen)</strong></label>
+              <label class="zadark-switch__label" for="js-switch-block-seen">
+                Ẩn trạng thái <strong>Đã xem (Seen)</strong>
+                <i class="zadark-icon zadark-icon--question" data-tippy-content='<p style="text-align: justify;">Người khác sẽ không thấy trạng thái <strong>Đã xem (Seen)</strong> tin nhắn của bạn, nhưng bạn vẫn thấy trạng thái của họ.</p><p style="text-align: justify;">Tuy nhiên, trạng thái của các tin nhắn bạn đã xem trên Zalo PC sẽ <strong>không được đồng bộ</strong> với máy chủ Zalo, bạn cần phải xem lại tin nhắn trên Zalo Mobile để đồng bộ.</p>'></i>
+              </label>
               <span class="zadark-switch__hotkeys">
                 <span class="zadark-hotkeys" data-keys-win="Ctrl+6" data-keys-mac="⌘6"></span>
               </span>
@@ -844,15 +852,17 @@
   `
 
   const zadarkPopupHTML = `
-    <div id="zadark-popup" class="zadark-popper">
-      <div id="js-zadark-popup__scrollable" class="zadark-popup__scrollable">
-        ${popupHeaderHTML}
-        ${popupMainHTML}
-        ${popupFooterHTML}
+    <div id="js-zadark-popup" class="zadark-popper">
+      <div id="zadark-popup">
+        <div id="js-zadark-popup__scrollable" class="zadark-popup__scrollable">
+          ${popupHeaderHTML}
+          ${popupMainHTML}
+          ${popupFooterHTML}
 
-        <button id="js-btn-scroll" data-tippy-content="Cuộn xuống">
-          <svg xmlns="http://www.w3.org/2000/svg" height="1em" viewBox="0 0 448 512"><path d="M413.1 222.5l22.2 22.2c9.4 9.4 9.4 24.6 0 33.9L241 473c-9.4 9.4-24.6 9.4-33.9 0L12.7 278.6c-9.4-9.4-9.4-24.6 0-33.9l22.2-22.2c9.5-9.5 25-9.3 34.3.4L184 343.4V56c0-13.3 10.7-24 24-24h32c13.3 0 24 10.7 24 24v287.4l114.8-120.5c9.3-9.8 24.8-10 34.3-.4z" fill="currentColor" /></svg>
-        </button>
+          <button id="js-btn-scroll" data-tippy-content="Cuộn xuống">
+            <svg xmlns="http://www.w3.org/2000/svg" height="1em" viewBox="0 0 448 512"><path d="M413.1 222.5l22.2 22.2c9.4 9.4 9.4 24.6 0 33.9L241 473c-9.4 9.4-24.6 9.4-33.9 0L12.7 278.6c-9.4-9.4-9.4-24.6 0-33.9l22.2-22.2c9.5-9.5 25-9.3 34.3.4L184 343.4V56c0-13.3 10.7-24 24-24h32c13.3 0 24 10.7 24 24v287.4l114.8-120.5c9.3-9.8 24.8-10 34.3-.4z" fill="currentColor" /></svg>
+          </button>
+        </div>
       </div>
     </div>
   `
@@ -1118,7 +1128,7 @@
     tippy('#js-input-font-family', {
       theme: 'zadark',
       allowHTML: true,
-      content: '<p>Nhập tên phông chữ từ <strong>Google Fonts</strong><br>(Lưu ý kí tự in hoa, khoảng cách).</p><p>Bỏ trống nếu dùng phông mặc định.</p><p>Nhấn <strong>Enter</strong> để lưu lại.</p>',
+      content: '<p>Nhập tên phông chữ từ <strong>Google Fonts</strong><br>(Lưu ý kí tự in hoa, khoảng cách).</p><p>Bỏ trống nếu dùng phông mặc định.</p><p>Nhấn <strong>Enter</strong> để áp dụng.</p>',
       trigger: 'focus'
     })
   }
@@ -1153,7 +1163,7 @@
 
     $(switchUseHotkeysElName).on('change', handleUseHotkeysChange)
 
-    const popupEl = document.querySelector('#zadark-popup')
+    const popupEl = document.querySelector('#js-zadark-popup')
     const buttonEl = document.getElementById('div_Main_TabZaDark')
 
     const popupInstance = Popper.createPopper(buttonEl, popupEl, {

--- a/src/pc/constants.js
+++ b/src/pc/constants.js
@@ -1,4 +1,5 @@
 const os = require('os')
+const path = require('path')
 const packageJSON = require('./package.json')
 
 const PLATFORM = os.platform()
@@ -11,7 +12,7 @@ const ZADARK_VERSION = packageJSON.version
 
 const DEFAULT_ZALO_PATH = IS_MAC
   ? '/Applications/Zalo.app' // ! Can't be changed
-  : process.env.USERPROFILE + '/AppData/Local/Programs/Zalo' // ! Can't be changed
+  : os.homedir() + '/AppData/Local/Programs/Zalo' // ! Can't be changed
 
 const EXAMPLE_CUSTOM_ZALO_PATH = IS_MAC
   ? '/ThuMucDaCaiZalo/Zalo.app'
@@ -29,6 +30,8 @@ const CONTACT_URL = 'https://zadark.quaric.com/contact'
 
 const FEEDBACK_UNINSTALL_URL = `https://docs.google.com/forms/d/e/1FAIpQLSdLonVbx-IavimDRneKuUhtMox4vDbyu35tB6uzQG8FGJFbUg/viewform?usp=pp_url&entry.454875478=${IS_MAC ? 'macOS' : 'Windows'}`
 
+const CONFIG_FILE_PATH = path.join(os.homedir(), '.zadarkconfig')
+
 module.exports = {
   PLATFORM,
   OS_NAME,
@@ -44,5 +47,7 @@ module.exports = {
   DOWNLOAD_ZADARK_URL,
   COMMON_ERRORS_URL,
   CONTACT_URL,
-  FEEDBACK_UNINSTALL_URL
+  FEEDBACK_UNINSTALL_URL,
+
+  CONFIG_FILE_PATH
 }

--- a/src/pc/index.js
+++ b/src/pc/index.js
@@ -152,8 +152,6 @@ const requestQuitTermProgram = () => {
   if (shouldUseCommand) {
     const zaloResDirList = zadarkPC.getZaloResDirList(zaloPath || DEFAULT_ZALO_PATH)
 
-    print('')
-
     try {
       if (!zaloResDirList.length) {
         throw new Error(`Khong tim thay Zalo PC (${zaloPath || DEFAULT_ZALO_PATH}).\nVui long cai dat Zalo PC : https://zalo.me/pc`)

--- a/src/pc/index.js
+++ b/src/pc/index.js
@@ -170,8 +170,6 @@ const requestQuitTermProgram = () => {
       print(chalk.magentaBright.bold('[XAY RA LOI]'))
       print('')
       printError(error.message)
-    } finally {
-      print('')
     }
     return
   }

--- a/src/pc/package.json
+++ b/src/pc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadark-pc",
   "description": "Dark Mode tốt nhất cho Zalo",
-  "version": "9.5",
+  "version": "9.6",
   "main": "index.js",
   "repository": "https://github.com/quaric/zadark.git",
   "author": {

--- a/src/pc/packages/ps-list/index.js
+++ b/src/pc/packages/ps-list/index.js
@@ -4,6 +4,7 @@ const util = require('util')
 const path = require('path')
 const childProcess = require('child_process')
 const fs = require('fs')
+const os = require('os')
 
 const TEN_MEGABYTES = 1000 * 1000 * 10
 const execFile = util.promisify(childProcess.execFile)
@@ -23,7 +24,7 @@ const windows = async () => {
       throw new Error(`Khong ho tro kien truc : ${process.arch}`)
   }
 
-  const zadarkPath = path.join(process.env.USERPROFILE, '/.zadark-cli')
+  const zadarkPath = path.join(os.homedir(), '/.zadark')
   const srcPath = path.join(__dirname, './vendor', bin)
   const destPath = path.join(zadarkPath, bin)
 

--- a/src/pc/utils.js
+++ b/src/pc/utils.js
@@ -3,7 +3,7 @@ const fs = require('fs')
 const path = require('path')
 const crossSpawn = require('cross-spawn')
 
-const { IS_MAC, IS_DEV } = require('./constants')
+const { IS_MAC, IS_DEV, CONFIG_FILE_PATH } = require('./constants')
 
 const print = (...args) => console.log(args.join(' '))
 const printDebug = (...args) => IS_DEV ? print(chalk.gray(...args)) : null
@@ -56,6 +56,24 @@ const killProcesses = (processIds = []) => {
   processIds.forEach((pid) => killProcess(pid))
 }
 
+const saveUserSettings = (settings) => {
+  try {
+    fs.writeFileSync(CONFIG_FILE_PATH, JSON.stringify(settings))
+    return true
+  } catch (err) {
+    return false
+  }
+}
+
+const loadUserSettings = () => {
+  try {
+    const data = fs.readFileSync(CONFIG_FILE_PATH, 'utf-8')
+    return JSON.parse(data)
+  } catch (err) {
+    return {}
+  }
+}
+
 module.exports = {
   print,
   printDebug,
@@ -67,5 +85,8 @@ module.exports = {
   isRoot,
 
   killProcess,
-  killProcesses
+  killProcesses,
+
+  saveUserSettings,
+  loadUserSettings
 }

--- a/src/web/js/popup.js
+++ b/src/web/js/popup.js
@@ -11,7 +11,7 @@ const MSG_ACTIONS = ZaDarkUtils.MSG_ACTIONS
 
 window.WebFontConfig = {
   google: {
-    families: ['Open Sans:400,600']
+    families: ['Open Sans:400,500,600']
   }
 };
 

--- a/src/web/js/utils.js
+++ b/src/web/js/utils.js
@@ -234,11 +234,11 @@
       const { fontFamily } = await ZaDarkBrowser.getExtensionSettings()
 
       if (!fontFamily) {
-        this.installFontFamily(['Open Sans:400,600:latin,vietnamese'], false)
+        this.installFontFamily(['Open Sans:400,500,600:latin,vietnamese'], false)
         return
       }
 
-      await this.installFontFamily(['Open Sans:400,600:latin,vietnamese', `${fontFamily}:400,500:latin,vietnamese`], false)
+      await this.installFontFamily(['Open Sans:400,500,600:latin,vietnamese', `${fontFamily}:400,500,600:latin,vietnamese`], false)
       this.setFontFamilyAttr(fontFamily)
     },
 
@@ -312,7 +312,7 @@
       tippy('#js-input-font-family', {
         theme: 'zadark',
         allowHTML: true,
-        content: '<p>Nhập tên phông chữ từ <strong>Google Fonts</strong><br>(Lưu ý kí tự in hoa, khoảng cách).</p><p>Bỏ trống nếu dùng phông mặc định.</p><p>Nhấn <strong>Enter</strong> để lưu lại.</p>',
+        content: '<p>Nhập tên phông chữ từ <strong>Google Fonts</strong><br>(Lưu ý kí tự in hoa, khoảng cách).</p><p>Bỏ trống nếu dùng phông mặc định.</p><p>Nhấn <strong>Enter</strong> để áp dụng.</p>',
         trigger: 'focus'
       })
     },

--- a/src/web/js/zadark.js
+++ b/src/web/js/zadark.js
@@ -194,7 +194,6 @@
           <div class="font-settings font-settings--border-default">
             <label class="font-settings__label">
               Phông chữ từ <a href="https://zadark.quaric.com/blog/use-google-fonts" target="_blank">Google Fonts</a>
-              <span class="zadark-beta"></span>
             </label>
 
             <input id="js-input-font-family" class="zadark-input" placeholder="Mặc định">
@@ -225,7 +224,7 @@
             <div class="zadark-switch">
               <label class="zadark-switch__label zadark-switch__label--helper" for="js-switch-hide-latest-message">
                 Ẩn <strong>Tin nhắn gần nhất</strong>
-                <i class="zadark-icon zadark-icon--question" data-tippy-content='<p>Để xem nội dung tin nhắn, bạn di chuột vào "<strong>Tên cuộc trò chuyện</strong>" cần xem.</p>'></i>
+                <i class="zadark-icon zadark-icon--question" data-tippy-content='Để xem nội dung tin nhắn, bạn di chuột vào<br/>"<strong>Tên cuộc trò chuyện</strong>" cần xem.'></i>
               </label>
               <span class="zadark-switch__hotkeys">
                 <span class="zadark-hotkeys" data-keys-win="Ctrl+1" data-keys-mac="⌘1"></span>
@@ -239,7 +238,6 @@
             <div class="zadark-switch zadark-switch--border-default">
               <label class="zadark-switch__label zadark-switch__label--helper" for="js-switch-hide-thread-chat-message">
                 Ẩn <strong>Tin nhắn</strong> trong cuộc trò chuyện
-                <!-- <i class="zadark-icon zadark-icon--question" data-tippy-content='<p>Để xem nội dung tin nhắn, bạn di chuột vào "<strong>Vùng hiển thị tin nhắn</strong>". Khi bạn di chuột ra khỏi vùng này, tin nhắn sẽ được ẩn đi.</p>'></i> -->
                 <i class="zadark-icon zadark-icon--play-circle" data-zdk-intro="hideThreadChatMessage" data-tippy-content="Nhấn vào để xem hướng dẫn"></i>
               </label>
               <span class="zadark-switch__hotkeys">
@@ -254,7 +252,7 @@
             <div class="zadark-switch">
               <label class="zadark-switch__label zadark-switch__label--helper" for="js-switch-hide-conv-avatar">
                 Ẩn <strong>Ảnh đại diện</strong> cuộc trò chuyện
-                <i class="zadark-icon zadark-icon--question" data-tippy-content='<p>Để xem Ảnh đại diện, bạn di chuyển chuột vào "<strong>Ảnh đại diện</strong>" cần xem.</p>'></i>
+                <i class="zadark-icon zadark-icon--question" data-tippy-content='Để xem Ảnh đại diện, bạn di chuyển chuột vào<br/>"<strong>Ảnh đại diện</strong>" cần xem.'></i>
               </label>
               <span class="zadark-switch__hotkeys">
                 <span class="zadark-hotkeys" data-keys-win="Ctrl+3" data-keys-mac="⌘3"></span>
@@ -268,7 +266,7 @@
             <div class="zadark-switch zadark-switch--border-default">
               <label class="zadark-switch__label zadark-switch__label--helper" for="js-switch-hide-conv-name">
                 Ẩn <strong>Tên</strong> cuộc trò chuyện
-                <i class="zadark-icon zadark-icon--question" data-tippy-content='<p>Để xem Tên cuộc trò chuyện, bạn di chuyển chuột vào "<strong>Tên cuộc trò chuyện</strong>" cần xem.</p>'></i>
+                <i class="zadark-icon zadark-icon--question" data-tippy-content='Để xem Tên cuộc trò chuyện, bạn di chuyển chuột vào "<strong>Tên cuộc trò chuyện</strong>" cần xem.'></i>
               </label>
               <span class="zadark-switch__hotkeys">
                 <span class="zadark-hotkeys" data-keys-win="Ctrl+7" data-keys-mac="⌘7"></span>
@@ -280,7 +278,10 @@
             </div>
 
             <div class="zadark-switch">
-              <label class="zadark-switch__label" for="js-switch-block-typing">Ẩn trạng thái <strong>Đang soạn tin (Typing) ...</strong></label>
+              <label class="zadark-switch__label zadark-switch__label--helper" for="js-switch-block-typing">
+                Ẩn trạng thái <strong>Đang soạn tin (Typing)</strong>
+                <i class="zadark-icon zadark-icon--question" data-tippy-content='<p style="text-align: justify;">Người khác sẽ không thấy trạng thái <strong>Đang soạn tin (Typing) ...</strong> của bạn, nhưng bạn vẫn thấy trạng thái của họ. Đây là điểm khác biệt giữa cài đặt từ ZaDark và Zalo.</p>'></i>
+              </label>
               <span class="zadark-switch__hotkeys">
                 <span class="zadark-hotkeys" data-keys-win="Ctrl+4" data-keys-mac="⌘4"></span>
               </span>
@@ -291,7 +292,10 @@
             </div>
 
             <div class="zadark-switch">
-              <label class="zadark-switch__label" for="js-switch-block-delivered">Ẩn trạng thái <strong>Đã nhận (Received)</strong></label>
+              <label class="zadark-switch__label zadark-switch__label--helper" for="js-switch-block-delivered">
+                Ẩn trạng thái <strong>Đã nhận (Received)</strong>
+                <i class="zadark-icon zadark-icon--question" data-tippy-content='<p style="text-align: justify;">Người khác sẽ không thấy trạng thái <strong>Đã nhận (Received)</strong> tin nhắn của bạn, nhưng bạn vẫn thấy trạng thái của họ.</p>'></i>
+              </label>
               <span class="zadark-switch__hotkeys">
                 <span class="zadark-hotkeys" data-keys-win="Ctrl+5" data-keys-mac="⌘5"></span>
               </span>
@@ -302,7 +306,10 @@
             </div>
 
             <div class="zadark-switch">
-              <label class="zadark-switch__label" for="js-switch-block-seen">Ẩn trạng thái <strong>Đã xem (Seen)</strong></label>
+              <label class="zadark-switch__label" for="js-switch-block-seen">
+                Ẩn trạng thái <strong>Đã xem (Seen)</strong>
+                <i class="zadark-icon zadark-icon--question" data-tippy-content='<p style="text-align: justify;">Người khác sẽ không thấy trạng thái <strong>Đã xem (Seen)</strong> tin nhắn của bạn, nhưng bạn vẫn thấy trạng thái của họ.</p><p style="text-align: justify;">Tuy nhiên, trạng thái của các tin nhắn bạn đã xem trên Zalo Web sẽ <strong>không được đồng bộ</strong> với máy chủ Zalo, bạn cần phải xem lại tin nhắn trên Zalo Mobile để đồng bộ.</p>'></i>
+              </label>
               <span class="zadark-switch__hotkeys">
                 <span class="zadark-hotkeys" data-keys-win="Ctrl+6" data-keys-mac="⌘6"></span>
               </span>
@@ -346,15 +353,17 @@
   `
 
   const zadarkPopupHTML = `
-    <div id="zadark-popup" class="zadark-popper">
-      <div id="js-zadark-popup__scrollable" class="zadark-popup__scrollable">
-        ${popupHeaderHTML}
-        ${popupMainHTML}
-        ${popupFooterHTML}
+    <div id="js-zadark-popup" class="zadark-popper">
+      <div id="zadark-popup">
+        <div id="js-zadark-popup__scrollable" class="zadark-popup__scrollable">
+          ${popupHeaderHTML}
+          ${popupMainHTML}
+          ${popupFooterHTML}
 
-        <button id="js-btn-scroll" data-tippy-content="Cuộn xuống">
-          <svg xmlns="http://www.w3.org/2000/svg" height="1em" viewBox="0 0 448 512"><path d="M413.1 222.5l22.2 22.2c9.4 9.4 9.4 24.6 0 33.9L241 473c-9.4 9.4-24.6 9.4-33.9 0L12.7 278.6c-9.4-9.4-9.4-24.6 0-33.9l22.2-22.2c9.5-9.5 25-9.3 34.3.4L184 343.4V56c0-13.3 10.7-24 24-24h32c13.3 0 24 10.7 24 24v287.4l114.8-120.5c9.3-9.8 24.8-10 34.3-.4z" fill="currentColor" /></svg>
-        </button>
+          <button id="js-btn-scroll" data-tippy-content="Cuộn xuống">
+            <svg xmlns="http://www.w3.org/2000/svg" height="1em" viewBox="0 0 448 512"><path d="M413.1 222.5l22.2 22.2c9.4 9.4 9.4 24.6 0 33.9L241 473c-9.4 9.4-24.6 9.4-33.9 0L12.7 278.6c-9.4-9.4-9.4-24.6 0-33.9l22.2-22.2c9.5-9.5 25-9.3 34.3.4L184 343.4V56c0-13.3 10.7-24 24-24h32c13.3 0 24 10.7 24 24v287.4l114.8-120.5c9.3-9.8 24.8-10 34.3-.4z" fill="currentColor" /></svg>
+          </button>
+        </div>
       </div>
     </div>
   `
@@ -659,7 +668,7 @@
 
     $(switchUseHotkeysElName).on('change', handleUseHotkeysChange)
 
-    const popupEl = document.querySelector('#zadark-popup')
+    const popupEl = document.querySelector('#js-zadark-popup')
     const buttonEl = document.getElementById('div_Main_TabZaDark')
 
     const popupInstance = Popper.createPopper(buttonEl, popupEl, {

--- a/src/web/popup.html
+++ b/src/web/popup.html
@@ -76,7 +76,6 @@
         <div class="font-settings font-settings--border-default">
           <label class="font-settings__label">
             Phông chữ từ <a href="https://zadark.quaric.com/blog/use-google-fonts" target="_blank">Google Fonts</a>
-            <span class="zadark-beta"></span>
           </label>
 
           <input id="js-input-font-family" class="zadark-input" placeholder="Mặc định">
@@ -109,7 +108,7 @@
           <div class="zadark-switch">
             <label class="zadark-switch__label zadark-switch__label--helper" for="js-switch-hide-latest-message">
               Ẩn <strong>Tin nhắn gần nhất</strong>
-              <i class="zadark-icon zadark-icon--question" data-tippy-content='<p>Để xem nội dung tin nhắn, bạn di chuột vào "<strong>Tên cuộc trò chuyện</strong>" cần xem.</p>'></i>
+              <i class="zadark-icon zadark-icon--question" data-tippy-content='Để xem nội dung tin nhắn, bạn di chuột vào<br/>"<strong>Tên cuộc trò chuyện</strong>" cần xem.'></i>
             </label>
             <span class="zadark-switch__hotkeys">
               <span class="zadark-hotkeys" data-keys-win="Ctrl+1" data-keys-mac="⌘1"></span>
@@ -123,7 +122,7 @@
           <div class="zadark-switch zadark-switch--border-default">
             <label class="zadark-switch__label zadark-switch__label--helper" for="js-switch-hide-thread-chat-message">
               Ẩn <strong>Tin nhắn</strong> trong cuộc trò chuyện
-              <i class="zadark-icon zadark-icon--question" data-tippy-content='<p>Truy cập <strong>Cài đặt ZaDark</strong> trên Zalo Web<br/>để xem hướng dẫn</p>'></i>
+              <i class="zadark-icon zadark-icon--question" data-tippy-content='Truy cập <strong>Cài đặt ZaDark</strong> trên Zalo Web<br/>để xem hướng dẫn.'></i>
             </label>
             <span class="zadark-switch__hotkeys">
               <span class="zadark-hotkeys" data-keys-win="Ctrl+2" data-keys-mac="⌘2"></span>
@@ -137,7 +136,7 @@
           <div class="zadark-switch">
             <label class="zadark-switch__label zadark-switch__label--helper" for="js-switch-hide-conv-avatar">
               Ẩn <strong>Ảnh đại diện</strong> cuộc trò chuyện
-              <i class="zadark-icon zadark-icon--question" data-tippy-content='<p>Để xem Ảnh đại diện, bạn di chuyển chuột vào "<strong>Ảnh đại diện</strong>" cần xem.</p>'></i>
+              <i class="zadark-icon zadark-icon--question" data-tippy-content='Để xem Ảnh đại diện, bạn di chuyển chuột vào<br/>"<strong>Ảnh đại diện</strong>" cần xem.'></i>
             </label>
             <span class="zadark-switch__hotkeys">
               <span class="zadark-hotkeys" data-keys-win="Ctrl+3" data-keys-mac="⌘3"></span>
@@ -151,7 +150,7 @@
           <div class="zadark-switch zadark-switch--border-default">
             <label class="zadark-switch__label zadark-switch__label--helper" for="js-switch-hide-conv-name">
               Ẩn <strong>Tên</strong> cuộc trò chuyện
-              <i class="zadark-icon zadark-icon--question" data-tippy-content='<p>Để xem Tên cuộc trò chuyện, bạn di chuyển chuột vào "<strong>Tên cuộc trò chuyện</strong>" cần xem.</p>'></i>
+              <i class="zadark-icon zadark-icon--question" data-tippy-content='Để xem Tên cuộc trò chuyện, bạn di chuyển chuột vào "<strong>Tên cuộc trò chuyện</strong>" cần xem.'></i>
             </label>
             <span class="zadark-switch__hotkeys">
               <span class="zadark-hotkeys" data-keys-win="Ctrl+7" data-keys-mac="⌘7"></span>
@@ -163,7 +162,10 @@
           </div>
 
           <div class="zadark-switch">
-            <label class="zadark-switch__label" for="js-switch-block-typing">Ẩn trạng thái <strong>Đang soạn tin (Typing) ...</strong></label>
+            <label class="zadark-switch__label zadark-switch__label--helper" for="js-switch-block-typing">
+              Ẩn trạng thái <strong>Đang soạn tin (Typing)</strong>
+              <i class="zadark-icon zadark-icon--question" data-tippy-content='<p style="text-align: justify;">Người khác sẽ không thấy trạng thái <strong>Đang soạn tin (Typing) ...</strong> của bạn, nhưng bạn vẫn thấy trạng thái của họ. Đây là điểm khác biệt giữa cài đặt từ ZaDark và Zalo.</p>'></i>
+            </label>
             <span class="zadark-switch__hotkeys">
               <span class="zadark-hotkeys" data-keys-win="Ctrl+4" data-keys-mac="⌘4"></span>
             </span>
@@ -174,7 +176,10 @@
           </div>
 
           <div class="zadark-switch">
-            <label class="zadark-switch__label" for="js-switch-block-delivered">Ẩn trạng thái <strong>Đã nhận (Received)</strong></label>
+            <label class="zadark-switch__label zadark-switch__label--helper" for="js-switch-block-delivered">
+              Ẩn trạng thái <strong>Đã nhận (Received)</strong>
+              <i class="zadark-icon zadark-icon--question" data-tippy-content='<p style="text-align: justify;">Người khác sẽ không thấy trạng thái <strong>Đã nhận (Received)</strong> tin nhắn của bạn, nhưng bạn vẫn thấy trạng thái của họ.</p>'></i>
+            </label>
             <span class="zadark-switch__hotkeys">
               <span class="zadark-hotkeys" data-keys-win="Ctrl+5" data-keys-mac="⌘5"></span>
             </span>
@@ -185,7 +190,10 @@
           </div>
 
           <div class="zadark-switch">
-            <label class="zadark-switch__label" for="js-switch-block-seen">Ẩn trạng thái <strong>Đã xem (Seen)</strong></label>
+            <label class="zadark-switch__label" for="js-switch-block-seen">
+              Ẩn trạng thái <strong>Đã xem (Seen)</strong>
+              <i class="zadark-icon zadark-icon--question" data-tippy-content='<p style="text-align: justify;">Người khác sẽ không thấy trạng thái <strong>Đã xem (Seen)</strong> tin nhắn của bạn, nhưng bạn vẫn thấy trạng thái của họ.</p><p style="text-align: justify;">Tuy nhiên, trạng thái của các tin nhắn bạn đã xem trên Zalo Web sẽ <strong>không được đồng bộ</strong> với máy chủ Zalo, bạn cần phải xem lại tin nhắn trên Zalo Mobile để đồng bộ.</p>'></i>
+            </label>
             <span class="zadark-switch__hotkeys">
               <span class="zadark-hotkeys" data-keys-win="Ctrl+6" data-keys-mac="⌘6"></span>
             </span>

--- a/src/web/vendor/chrome/manifest.json
+++ b/src/web/vendor/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ZaDark – Zalo Dark Mode",
-  "version": "9.5",
+  "version": "9.6",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "Quaric",

--- a/src/web/vendor/edge/manifest.json
+++ b/src/web/vendor/edge/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ZaDark – Zalo Dark Mode",
-  "version": "9.5",
+  "version": "9.6",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "Quaric",

--- a/src/web/vendor/firefox/manifest.json
+++ b/src/web/vendor/firefox/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "ZaDark – Zalo Dark Mode",
-  "version": "9.5",
+  "version": "9.6",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "Quaric",

--- a/src/web/vendor/opera/manifest.json
+++ b/src/web/vendor/opera/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ZaDark – Zalo Dark Mode",
-  "version": "9.5",
+  "version": "9.6",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "Quaric",

--- a/src/web/vendor/safari/manifest.json
+++ b/src/web/vendor/safari/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "ZaDark – Zalo Dark Mode",
-  "version": "9.5",
+  "version": "9.6",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "Quaric",


### PR DESCRIPTION
# ZaDark 23.7.5
> PC 9.6 && Web 9.6

## Added
- Bổ sung giải thích (Tooltip) cho chức năng
  - Ẩn trạng thái Đang soạn tin (Typing) ...
  - Ẩn trạng thái Đã nhận (Received)
  - Ẩn trạng thái Đã xem (Seen)

### PC specific
- Thêm chế độ cài đặt / gỡ cài đặt nhanh **bằng câu lệnh**
  - Windows
    - Giải nén file `ZaDark.zip`, mở **Terminal** hoặc **Command Prompt**
    - Nhập cú pháp cài ZaDark
      - `"\Thu_Muc_Chua_File_ZaDark\ZaDark 9.6.exe" install` hoặc
      - `"\Thu_Muc_Chua_File_ZaDark\ZaDark 9.6.exe" in`
    - Nhập cú pháp gỡ ZaDark
      - `"\Thu_Muc_Chua_File_ZaDark\ZaDark 9.6.exe" uninstall` hoặc
      - `"\Thu_Muc_Chua_File_ZaDark\ZaDark 9.6.exe" un`
    - Ví dụ
      - `"C:\Users\ncdai\Downloads\ZaDark 9.6\ZaDark 9.6.exe" install`
  - macOS
    - Sau khi chạy file `ZaDark.pkg`, mở **Terminal**
    - Nhập cú pháp cài ZaDark
      - `/Applications/ZaDark install` hoặc
      - `/Applications/ZaDark in`
    - Nhập cú pháp gỡ ZaDark
      - `/Applications/ZaDark uninstall` hoặc
      - `/Applications/ZaDark un`
- Chỉ mở Feedback Unsintall khi người dùng gỡ cài đặt ZaDark lần đầu
- ZaDark lưu cài đặt vào đường dẫn
  - Windows: `C:\Users\TenNguoiDung\.zadarkconfig`
  - macOS: `/Users/TenNguoiDung/.zadarkconfig`
  - Mục đích
    - Xác định có phải người dùng gỡ cài đặt lần đầu không
    - Chuẩn bị cho tính năng Auto Update ZaDark, Auto Reinstall ZaDark
- **[Windows]** Thay thay đổi đường dẫn chứa chương trình [**fastlist**](https://github.com/MarkTiedemann/fastlist) (Chương trình giúp ZaDark xác định Process ID của Zalo để tắt Zalo trước khi cài đặt)
  - `C:\Users\TenNguoiDung\.zadark\fastlist-0.3.0.exe`

## Changed
- Thêm màu nền tối (Overlay) giúp người dùng tập trung vào Popup cài đặt ZaDark hơn
- Bỏ nhãn BETA của cài đặt phông chữ từ Google Fonts
- Ẩn Tin nhắn gần nhất: Giữ lại Nhãn (Label) cuộc trò chuyện ([#57](https://github.com/quaric/zadark/issues/57))