### PR TITLE
Hotfix/23.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## ZaDark 23.8.1
+
+> PC 10.0
+
+### Fixed
+
+- **[Windows]** Sửa lỗi ZaDark không hoạt động trên **Zalo PC 23.7.1** trở lên (Vì Zalo nâng cấp mã nguồn)
+
+### Removed
+- Tính năng **Ẩn trạng thái (Đang soạn tin, Đã nhận, Đã xem)** không khả dụng trên **Zalo PC 23.7.1** trở lên
+- **[Windows]** Hộp thoại thông báo chỉ hỗ trợ Dark Mode (Light Mode, ẩn tin nhắn, ảnh đại diện và tên không khả dụng) trên **Zalo PC 23.7.1** trở lên
+> Vì Zalo nâng cấp mã nguồn, ZaDark sẽ cập nhật trong thời gian tới
+
 ## ZaDark 23.7.5
 > PC 9.6 && Web 9.6
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadark",
   "description": "Dark Mode tốt nhất cho Zalo",
-  "version": "23.7.5",
+  "version": "23.8.1",
   "repository": "https://github.com/quaric/zadark.git",
   "author": {
     "name": "Quaric",

--- a/src/core/scss/zadark-popup.scss
+++ b/src/core/scss/zadark-popup.scss
@@ -492,7 +492,8 @@ body:not(.zadark--use-hotkeys) {
       }
 
       .zadark-switch__label,
-      .zadark-switch__checkbox {
+      .zadark-switch__checkbox,
+      .zadark-switch__hotkeys {
         opacity: 0.25;
       }
     }
@@ -720,6 +721,10 @@ body:not(.zadark--use-hotkeys) {
   cursor: pointer;
   text-decoration: none;
   transition: all 0.3s cubic-bezier(0.215, 0.61, 0.355, 1);
+
+  &--error {
+    border-color: #e74c3c;
+  }
 }
 
 .toastify.on {

--- a/src/pc/assets/js/zadark-znotification.js
+++ b/src/pc/assets/js/zadark-znotification.js
@@ -4,7 +4,20 @@
 */
 
 (function () {
-  const { ipcRenderer } = require('electron')
+  let ipcRenderer = {
+    invoke: () => {
+      return Promise.resolve({
+        theme: 'dark',
+        hideLatestMessage: false,
+        hideConvAvatar: false,
+        hideConvName: false
+      })
+    }
+  }
+
+  if (typeof require === 'function') {
+    ipcRenderer = require('electron').ipcRenderer
+  }
 
   const ZaDarkUtils = {
     setThemeAttr: (themeMode) => {

--- a/src/pc/package.json
+++ b/src/pc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadark-pc",
   "description": "Dark Mode tốt nhất cho Zalo",
-  "version": "9.6",
+  "version": "10.0",
   "main": "index.js",
   "repository": "https://github.com/quaric/zadark.git",
   "author": {

--- a/src/pc/zadark-pc.js
+++ b/src/pc/zadark-pc.js
@@ -126,6 +126,12 @@ const writeIndexFile = (zaloDir) => {
     },
     // Required scripts
     {
+      selector: 'script[src="zadark-jquery.min.js"]',
+      where: 'beforeend',
+      html: '<script src="zadark-jquery.min.js"></script>',
+      htmlElement: bodyElement
+    },
+    {
       selector: 'script[src="zadark-popper.min.js"]',
       where: 'beforeend',
       html: '<script src="zadark-popper.min.js"></script>',
@@ -135,6 +141,30 @@ const writeIndexFile = (zaloDir) => {
       selector: 'script[src="zadark-tippy.min.js"]',
       where: 'beforeend',
       html: '<script src="zadark-tippy.min.js"></script>',
+      htmlElement: bodyElement
+    },
+    {
+      selector: 'script[src="zadark-hotkeys-js.min.js"]',
+      where: 'beforeend',
+      html: '<script src="zadark-hotkeys-js.min.js"></script>',
+      htmlElement: bodyElement
+    },
+    {
+      selector: 'script[src="zadark-toastify.min.js"]',
+      where: 'beforeend',
+      html: '<script src="zadark-toastify.min.js"></script>',
+      htmlElement: bodyElement
+    },
+    {
+      selector: 'script[src="zadark-webfont.min.js"]',
+      where: 'beforeend',
+      html: '<script src="zadark-webfont.min.js"></script>',
+      htmlElement: bodyElement
+    },
+    {
+      selector: 'script[src="zadark-introjs.min.js"]',
+      where: 'beforeend',
+      html: '<script src="zadark-introjs.min.js"></script>',
       htmlElement: bodyElement
     },
     {


### PR DESCRIPTION
## ZaDark 23.8.1

> PC 10.0

### Fixed

- **[Windows]** Sửa lỗi ZaDark không hoạt động trên **Zalo PC 23.7.1** trở lên (Vì Zalo nâng cấp mã nguồn)

### Removed
- Tính năng **Ẩn trạng thái (Đang soạn tin, Đã nhận, Đã xem)** không khả dụng trên **Zalo PC 23.7.1** trở lên
- **[Windows]** Hộp thoại thông báo chỉ hỗ trợ Dark Mode (Light Mode, ẩn tin nhắn, ảnh đại diện và tên không khả dụng) trên **Zalo PC 23.7.1** trở lên
> Vì Zalo nâng cấp mã nguồn, ZaDark sẽ cập nhật trong thời gian tới