### PR TITLE
Feature/23.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## ZaDark 23.8.3
+
+> PC 10.2 && Web 9.8
+
+### Fixed
+#### Web specific
+- **[Firefox]** Sửa lỗi không thể cài đặt phông chữ ([#74](https://github.com/quaric/zadark/issues/74))
+
+### Changed
+- Thay đổi màu sắc nhãn "Pro"
+- Thay đổi vị trí Popup Cài đặt ZaDark
+
 ## ZaDark 23.8.2
 
 > PC 10.1 && Web 9.7

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadark",
   "description": "Dark Mode tốt nhất cho Zalo",
-  "version": "23.8.2",
+  "version": "23.8.3",
   "repository": "https://github.com/quaric/zadark.git",
   "author": {
     "name": "Quaric",

--- a/src/core/scss/zadark-popup.scss
+++ b/src/core/scss/zadark-popup.scss
@@ -239,15 +239,15 @@ body:not(.zadark--use-hotkeys) {
       height: 18px;
 
       margin-left: 6px;
-      padding: 0 6px;
+      padding: 0 4px;
 
-      border: 1px solid var(--zadark-blue-base);
-      border-radius: 9px;
+      border: 1px solid var(--zadark-neutral-700);
+      border-radius: 4px;
 
       font-size: 12px;
       font-weight: var(--zadark-font-semibold);
       line-height: 12px;
-      color: var(--zadark-blue-base);
+      color: var(--zadark-neutral-500);
 
       &::after {
         content: "Pro";

--- a/src/pc/assets/js/zadark.js
+++ b/src/pc/assets/js/zadark.js
@@ -1210,7 +1210,7 @@
     const buttonEl = document.getElementById('div_Main_TabZaDark')
 
     const popupInstance = Popper.createPopper(buttonEl, popupEl, {
-      placement: 'right-start'
+      placement: 'right'
     })
 
     buttonEl.addEventListener('click', handleOpenZaDarkPopup(popupInstance, buttonEl, popupEl))

--- a/src/pc/package.json
+++ b/src/pc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadark-pc",
   "description": "Dark Mode tốt nhất cho Zalo",
-  "version": "10.1",
+  "version": "10.2",
   "main": "index.js",
   "repository": "https://github.com/quaric/zadark.git",
   "author": {

--- a/src/web/js/fonts.js
+++ b/src/web/js/fonts.js
@@ -22,7 +22,10 @@
 
         const googleFontsURL = `https://fonts.googleapis.com/css2?${normalizeFonts(fonts)}&display=swap`
 
-        fetch(googleFontsURL)
+        fetch(googleFontsURL, {
+          method: 'GET',
+          mode: 'no-cors'
+        })
           .then((response) => response.text())
           .then((cssContent) => {
             const blob = new Blob([cssContent], { type: 'text/css' })

--- a/src/web/js/fonts.js
+++ b/src/web/js/fonts.js
@@ -22,10 +22,7 @@
 
         const googleFontsURL = `https://fonts.googleapis.com/css2?${normalizeFonts(fonts)}&display=swap`
 
-        fetch(googleFontsURL, {
-          method: 'GET',
-          mode: 'no-cors'
-        })
+        fetch(googleFontsURL)
           .then((response) => response.text())
           .then((cssContent) => {
             const blob = new Blob([cssContent], { type: 'text/css' })

--- a/src/web/js/zadark.js
+++ b/src/web/js/zadark.js
@@ -673,7 +673,7 @@
     const buttonEl = document.getElementById('div_Main_TabZaDark')
 
     const popupInstance = Popper.createPopper(buttonEl, popupEl, {
-      placement: 'right-start'
+      placement: 'right'
     })
 
     buttonEl.addEventListener('click', handleOpenZaDarkPopup(popupInstance, buttonEl, popupEl))

--- a/src/web/popup.html
+++ b/src/web/popup.html
@@ -31,8 +31,14 @@
         <a href="https://zadark.canny.io" title="Phản hồi" target="_blank">Phản hồi</a>
       </span>
 
-      <span class="zadark-popup__header__menu-item">
+      <span class="zadark-popup__header__menu-item zadark-popup__header__menu-divider">
         <a href="https://zadark.quaric.com/blog/changelog" id="js-ext-version" title="Có gì mới trong phiên bản này?" target="_blank"></a>
+      </span>
+
+      <span class="zadark-popup__header__menu-item zadark-popup__header__menu-coffee">
+        <a href="https://zadark.quaric.com/donate" title="Donate" target="_blank">
+          <img src="/images/zadark-coffee.png" alt="Donate" />
+        </a>
       </span>
     </div>
   </div>

--- a/src/web/vendor/chrome/manifest.json
+++ b/src/web/vendor/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ZaDark – Zalo Dark Mode",
-  "version": "9.7",
+  "version": "9.8",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "Quaric",

--- a/src/web/vendor/edge/manifest.json
+++ b/src/web/vendor/edge/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ZaDark – Zalo Dark Mode",
-  "version": "9.7",
+  "version": "9.8",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "Quaric",

--- a/src/web/vendor/firefox/manifest.json
+++ b/src/web/vendor/firefox/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "ZaDark – Zalo Dark Mode",
-  "version": "9.7",
+  "version": "9.8",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "Quaric",

--- a/src/web/vendor/firefox/manifest.json
+++ b/src/web/vendor/firefox/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "ZaDark – Zalo Dark Mode",
-  "version": "9.8",
+  "version": "9.9",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "Quaric",
@@ -47,7 +47,8 @@
     "storage",
     "tabs",
     "declarativeNetRequest",
-    "*://chat.zalo.me/*"
+    "*://chat.zalo.me/*",
+    "*://fonts.googleapis.com/*"
   ],
   "declarative_net_request": {
     "rule_resources": [

--- a/src/web/vendor/opera/manifest.json
+++ b/src/web/vendor/opera/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ZaDark – Zalo Dark Mode",
-  "version": "9.7",
+  "version": "9.8",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "Quaric",

--- a/src/web/vendor/safari/ZaDark.xcodeproj/project.pbxproj
+++ b/src/web/vendor/safari/ZaDark.xcodeproj/project.pbxproj
@@ -485,7 +485,7 @@
 				CODE_SIGN_ENTITLEMENTS = "ZaDark Extension/ZaDark_Extension.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1691170392;
+				CURRENT_PROJECT_VERSION = 1691424663;
 				DEVELOPMENT_TEAM = YN8BK4969T;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -498,7 +498,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 9.7;
+				MARKETING_VERSION = 9.8;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -517,7 +517,7 @@
 				CODE_SIGN_ENTITLEMENTS = "ZaDark Extension/ZaDark_Extension.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1691170392;
+				CURRENT_PROJECT_VERSION = 1691424663;
 				DEVELOPMENT_TEAM = YN8BK4969T;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -530,7 +530,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 9.7;
+				MARKETING_VERSION = 9.8;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -552,7 +552,7 @@
 				CODE_SIGN_ENTITLEMENTS = ZaDark/ZaDark.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1691170392;
+				CURRENT_PROJECT_VERSION = 1691424663;
 				DEVELOPMENT_TEAM = YN8BK4969T;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -567,7 +567,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 9.7;
+				MARKETING_VERSION = 9.8;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -590,7 +590,7 @@
 				CODE_SIGN_ENTITLEMENTS = ZaDark/ZaDark.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1691170392;
+				CURRENT_PROJECT_VERSION = 1691424663;
 				DEVELOPMENT_TEAM = YN8BK4969T;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -605,7 +605,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 9.7;
+				MARKETING_VERSION = 9.8;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,

--- a/src/web/vendor/safari/manifest.json
+++ b/src/web/vendor/safari/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "ZaDark – Zalo Dark Mode",
-  "version": "9.7",
+  "version": "9.8",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "Quaric",


### PR DESCRIPTION
## ZaDark 23.8.3

> PC 10.2 && Web 9.8

### Fixed
#### Web specific
- **[Firefox]** Sửa lỗi không thể cài đặt phông chữ ([#74](https://github.com/quaric/zadark/issues/74))

### Changed
- Thay đổi màu sắc nhãn "Pro"
- Thay đổi vị trí Popup Cài đặt ZaDark