### PR TITLE
Feature/23.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## ZaDark 23.9.2
+> PC 11.3 và Web 9.13
+
+### Fixed
+- Tăng độ đậm cho nội dung được tô đậm (bold) trong tin nhắn ([#78](https://github.com/quaric/zadark/issues/78))
+
 ## ZaDark 23.9.1
 > PC 11.2 và Web 9.12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 > PC 11.3 và Web 9.13
 
 ### Fixed
-- Tăng độ đậm cho nội dung được tô đậm (bold) trong tin nhắn ([#78](https://github.com/quaric/zadark/issues/78))
+- Tăng độ đậm cho nội dung được tô đậm (bold) trong tin nhắn ([#78](https://github.com/quaric/zadark/issues/78)).
+- Sửa lỗi Dark Mode biểu tượng Phó nhóm.
 
 ## ZaDark 23.9.1
 > PC 11.2 và Web 9.12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@
 - Bổ sung phím tắt chuyển chế độ Sáng/Tối ([#79](https://github.com/quaric/zadark/issues/79))
   - Windows: `Alt+D`
   - macOS: `⌘D`
-  - Safari: `⌃D`
 
 ### Removed
 - Bỏ phím tắt mở Cài đặt ZaDark & thay bằng phím tắt chuyển chế độ Sáng/Tối.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,16 @@
 
 ### Fixed
 - Tăng độ đậm cho nội dung được tô đậm (bold) trong tin nhắn ([#78](https://github.com/quaric/zadark/issues/78)).
-- Sửa lỗi Dark Mode biểu tượng Phó nhóm.
+- Sửa lỗi Dark Mode biểu tượng Phó nhóm ([#80](https://github.com/quaric/zadark/issues/80)).
+
+### Added
+- Bổ sung phím tắt chuyển chế độ Sáng/Tối ([#79](https://github.com/quaric/zadark/issues/79))
+  - Windows: `Alt+D`
+  - macOS: `⌘D`
+  - Safari: `⌃D`
+
+### Removed
+- Bỏ phím tắt mở Cài đặt ZaDark & thay bằng phím tắt chuyển chế độ Sáng/Tối.
 
 ## ZaDark 23.9.1
 > PC 11.2 và Web 9.12

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadark",
   "description": "Dark Mode tốt nhất cho Zalo",
-  "version": "23.9.1",
+  "version": "23.9.2",
   "repository": "https://github.com/quaric/zadark.git",
   "author": {
     "name": "Quaric",

--- a/src/core/scss/zadark-popup.scss
+++ b/src/core/scss/zadark-popup.scss
@@ -407,10 +407,8 @@ body:not(.zadark--use-hotkeys) {
         flex: 1;
       }
 
-      // Description
-      span:nth-child(2) {
-        font-size: 12px;
-        color: var(--zadark-neutral-500);
+      .zadark-switch__hotkeys {
+        margin-right: 0;
       }
     }
 

--- a/src/core/scss/zadark.scss
+++ b/src/core/scss/zadark.scss
@@ -2033,6 +2033,15 @@ html[data-zadark-theme="dark"] {
     }
 
     // END: Video Player
+
+    .zavatar-admin {
+      color: var(--text-primary);
+      background: var(--NG30);
+
+      &.zavatar-admin_isOwner {
+        color: var(--Y50);
+      }
+    }
   }
 }
 

--- a/src/core/scss/zadark.scss
+++ b/src/core/scss/zadark.scss
@@ -2203,4 +2203,11 @@ body.zadark {
   .qrsc {
     border-radius: var(--zadark-rounded-base);
   }
+
+  .rich-text-input,
+  .editor-input {
+    span[style*="font-weight: 500"] {
+      font-weight: 600 !important;
+    }
+  }
 }

--- a/src/pc/assets/js/zadark.js
+++ b/src/pc/assets/js/zadark.js
@@ -765,7 +765,7 @@
               <span class="zadark-radio__label">
                 <span>Sáng</span>
                 <span class="zadark-switch__hotkeys">
-                  <span class="zadark-hotkeys" data-keys-win="Ctrl+D" data-keys-mac="⌘D" data-keys-safari="⌃D"></span>
+                  <span class="zadark-hotkeys" data-keys-win="Ctrl+D" data-keys-mac="⌘D"></span>
                 </span>
               </span>
             </label>
@@ -776,7 +776,7 @@
               <span class="zadark-radio__label">
                 <span>Tối</span>
                 <span class="zadark-switch__hotkeys">
-                  <span class="zadark-hotkeys" data-keys-win="Ctrl+D" data-keys-mac="⌘D" data-keys-safari="⌃D"></span>
+                  <span class="zadark-hotkeys" data-keys-win="Ctrl+D" data-keys-mac="⌘D"></span>
                 </span>
               </span>
             </label>

--- a/src/pc/assets/js/zadark.js
+++ b/src/pc/assets/js/zadark.js
@@ -613,6 +613,18 @@
     ZaDarkUtils.updateTheme(theme)
   }
 
+  const handleNextTheme = () => {
+    const theme = ZaDarkStorage.getTheme()
+
+    const themes = ['light', 'dark']
+
+    const nextIndex = themes.indexOf(theme) + 1
+    const nextTheme = themes[nextIndex] || themes[0]
+
+    setRadioInputTheme(nextTheme)
+    ZaDarkUtils.updateTheme(nextTheme)
+  }
+
   async function handleInputFontFamilyKeyPress (event) {
     const isEnter = Number(event.keyCode ? event.keyCode : event.which) - 1 === 12
 
@@ -752,6 +764,9 @@
               <span class="zadark-radio__checkmark"></span>
               <span class="zadark-radio__label">
                 <span>Sáng</span>
+                <span class="zadark-switch__hotkeys">
+                  <span class="zadark-hotkeys" data-keys-win="Ctrl+D" data-keys-mac="⌘D" data-keys-safari="⌃D"></span>
+                </span>
               </span>
             </label>
 
@@ -760,6 +775,9 @@
               <span class="zadark-radio__checkmark"></span>
               <span class="zadark-radio__label">
                 <span>Tối</span>
+                <span class="zadark-switch__hotkeys">
+                  <span class="zadark-hotkeys" data-keys-win="Ctrl+D" data-keys-mac="⌘D" data-keys-safari="⌃D"></span>
+                </span>
               </span>
             </label>
 
@@ -1073,11 +1091,10 @@
           return
         }
 
-        // Open ZaDark Settings
+        // Next theme
         case 'command+d':
         case 'ctrl+d': {
-          const buttonEl = document.getElementById('div_Main_TabZaDark')
-          buttonEl.click()
+          handleNextTheme()
         }
       }
     })

--- a/src/pc/assets/js/zadark.js
+++ b/src/pc/assets/js/zadark.js
@@ -1224,7 +1224,7 @@
     tippy('#div_Main_TabZaDark', {
       theme: 'zadark',
       allowHTML: true,
-      content: '<span>Cài đặt ZaDark <span class="zadark-hotkeys" data-keys-win="Ctrl+D" data-keys-mac="⌘D"></span></span>',
+      content: 'Cài đặt ZaDark',
       placement: 'right'
     })
 

--- a/src/pc/package.json
+++ b/src/pc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadark-pc",
   "description": "Dark Mode tốt nhất cho Zalo",
-  "version": "11.2",
+  "version": "11.3",
   "main": "index.js",
   "repository": "https://github.com/quaric/zadark.git",
   "author": {

--- a/src/web/js/utils.js
+++ b/src/web/js/utils.js
@@ -301,7 +301,7 @@
       tippy('#div_Main_TabZaDark', {
         theme: 'zadark',
         allowHTML: true,
-        content: '<span>Cài đặt ZaDark <span class="zadark-hotkeys" data-keys-win="Ctrl+D" data-keys-mac="⌘D"></span></span>',
+        content: 'Cài đặt ZaDark',
         placement: 'right'
       })
 

--- a/src/web/js/zadark.js
+++ b/src/web/js/zadark.js
@@ -46,6 +46,20 @@
     ZaDarkUtils.updateTheme(theme)
   }
 
+  const handleNextTheme = async () => {
+    const {
+      theme
+    } = await ZaDarkBrowser.getExtensionSettings()
+
+    const themes = ['light', 'dark']
+
+    const nextIndex = themes.indexOf(theme) + 1
+    const nextTheme = themes[nextIndex] || themes[0]
+
+    setRadioInputTheme(nextTheme)
+    ZaDarkUtils.updateTheme(nextTheme)
+  }
+
   async function handleInputFontFamilyKeyPress (event) {
     const isEnter = Number(event.keyCode ? event.keyCode : event.which) - 1 === 12
 
@@ -172,6 +186,9 @@
               <span class="zadark-radio__checkmark"></span>
               <span class="zadark-radio__label">
                 <span>Sáng</span>
+                <span class="zadark-switch__hotkeys">
+                  <span class="zadark-hotkeys" data-keys-win="Ctrl+D" data-keys-mac="⌘D" data-keys-safari="⌃D"></span>
+                </span>
               </span>
             </label>
 
@@ -180,6 +197,9 @@
               <span class="zadark-radio__checkmark"></span>
               <span class="zadark-radio__label">
                 <span>Tối</span>
+                <span class="zadark-switch__hotkeys">
+                  <span class="zadark-hotkeys" data-keys-win="Ctrl+D" data-keys-mac="⌘D" data-keys-safari="⌃D"></span>
+                </span>
               </span>
             </label>
 
@@ -520,11 +540,10 @@
           return
         }
 
-        // Open ZaDark Settings
+        // Next theme
         case 'command+d':
         case 'ctrl+d': {
-          const buttonEl = document.getElementById('div_Main_TabZaDark')
-          buttonEl.click()
+          handleNextTheme()
         }
       }
     })

--- a/src/web/js/zadark.js
+++ b/src/web/js/zadark.js
@@ -187,7 +187,7 @@
               <span class="zadark-radio__label">
                 <span>Sáng</span>
                 <span class="zadark-switch__hotkeys">
-                  <span class="zadark-hotkeys" data-keys-win="Ctrl+D" data-keys-mac="⌘D" data-keys-safari="⌃D"></span>
+                  <span class="zadark-hotkeys" data-keys-win="Ctrl+D" data-keys-mac="⌘D" data-keys-safari="⌘D"></span>
                 </span>
               </span>
             </label>
@@ -198,7 +198,7 @@
               <span class="zadark-radio__label">
                 <span>Tối</span>
                 <span class="zadark-switch__hotkeys">
-                  <span class="zadark-hotkeys" data-keys-win="Ctrl+D" data-keys-mac="⌘D" data-keys-safari="⌃D"></span>
+                  <span class="zadark-hotkeys" data-keys-win="Ctrl+D" data-keys-mac="⌘D" data-keys-safari="⌘D"></span>
                 </span>
               </span>
             </label>

--- a/src/web/popup.html
+++ b/src/web/popup.html
@@ -54,6 +54,9 @@
             <span class="zadark-radio__checkmark"></span>
             <span class="zadark-radio__label">
               <span>Sáng</span>
+              <span class="zadark-switch__hotkeys">
+                <span class="zadark-hotkeys" data-keys-win="Ctrl+D" data-keys-mac="⌘D" data-keys-safari="⌃D"></span>
+              </span>
             </span>
           </label>
 
@@ -62,6 +65,9 @@
             <span class="zadark-radio__checkmark"></span>
             <span class="zadark-radio__label">
               <span>Tối</span>
+              <span class="zadark-switch__hotkeys">
+                <span class="zadark-hotkeys" data-keys-win="Ctrl+D" data-keys-mac="⌘D" data-keys-safari="⌃D"></span>
+              </span>
             </span>
           </label>
 

--- a/src/web/popup.html
+++ b/src/web/popup.html
@@ -55,7 +55,7 @@
             <span class="zadark-radio__label">
               <span>Sáng</span>
               <span class="zadark-switch__hotkeys">
-                <span class="zadark-hotkeys" data-keys-win="Ctrl+D" data-keys-mac="⌘D" data-keys-safari="⌃D"></span>
+                <span class="zadark-hotkeys" data-keys-win="Ctrl+D" data-keys-mac="⌘D" data-keys-safari="⌘D"></span>
               </span>
             </span>
           </label>
@@ -66,7 +66,7 @@
             <span class="zadark-radio__label">
               <span>Tối</span>
               <span class="zadark-switch__hotkeys">
-                <span class="zadark-hotkeys" data-keys-win="Ctrl+D" data-keys-mac="⌘D" data-keys-safari="⌃D"></span>
+                <span class="zadark-hotkeys" data-keys-win="Ctrl+D" data-keys-mac="⌘D" data-keys-safari="⌘D"></span>
               </span>
             </span>
           </label>

--- a/src/web/vendor/chrome/manifest.json
+++ b/src/web/vendor/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ZaDark – Zalo Dark Mode",
-  "version": "9.12",
+  "version": "9.13",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "Quaric",

--- a/src/web/vendor/edge/manifest.json
+++ b/src/web/vendor/edge/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ZaDark – Zalo Dark Mode",
-  "version": "9.12",
+  "version": "9.13",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "Quaric",

--- a/src/web/vendor/firefox/manifest.json
+++ b/src/web/vendor/firefox/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "ZaDark – Zalo Dark Mode",
-  "version": "9.12",
+  "version": "9.13",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "Quaric",

--- a/src/web/vendor/opera/manifest.json
+++ b/src/web/vendor/opera/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ZaDark – Zalo Dark Mode",
-  "version": "9.12",
+  "version": "9.13",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "Quaric",

--- a/src/web/vendor/safari/ZaDark.xcodeproj/project.pbxproj
+++ b/src/web/vendor/safari/ZaDark.xcodeproj/project.pbxproj
@@ -485,7 +485,7 @@
 				CODE_SIGN_ENTITLEMENTS = "ZaDark Extension/ZaDark_Extension.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1694798561;
+				CURRENT_PROJECT_VERSION = 1695475327;
 				DEVELOPMENT_TEAM = YN8BK4969T;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -498,7 +498,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 9.12;
+				MARKETING_VERSION = 9.13;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -517,7 +517,7 @@
 				CODE_SIGN_ENTITLEMENTS = "ZaDark Extension/ZaDark_Extension.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1694798561;
+				CURRENT_PROJECT_VERSION = 1695475327;
 				DEVELOPMENT_TEAM = YN8BK4969T;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -530,7 +530,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 9.12;
+				MARKETING_VERSION = 9.13;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -552,7 +552,7 @@
 				CODE_SIGN_ENTITLEMENTS = ZaDark/ZaDark.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1694798561;
+				CURRENT_PROJECT_VERSION = 1695475327;
 				DEVELOPMENT_TEAM = YN8BK4969T;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -567,7 +567,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 9.12;
+				MARKETING_VERSION = 9.13;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -590,7 +590,7 @@
 				CODE_SIGN_ENTITLEMENTS = ZaDark/ZaDark.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1694798561;
+				CURRENT_PROJECT_VERSION = 1695475327;
 				DEVELOPMENT_TEAM = YN8BK4969T;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -605,7 +605,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 9.12;
+				MARKETING_VERSION = 9.13;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,

--- a/src/web/vendor/safari/manifest.json
+++ b/src/web/vendor/safari/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "ZaDark – Zalo Dark Mode",
-  "version": "9.12",
+  "version": "9.13",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "Quaric",


### PR DESCRIPTION
## ZaDark 23.9.2
> PC 11.3 và Web 9.13

### Fixed
- Tăng độ đậm cho nội dung được tô đậm (bold) trong tin nhắn ([#78](https://github.com/quaric/zadark/issues/78)).
- Sửa lỗi Dark Mode biểu tượng Phó nhóm ([#80](https://github.com/quaric/zadark/issues/80)).

### Added
- Bổ sung phím tắt chuyển chế độ Sáng/Tối ([#79](https://github.com/quaric/zadark/issues/79))
  - Windows: `Alt+D`
  - macOS: `⌘D`

### Removed
- Bỏ phím tắt mở Cài đặt ZaDark & thay bằng phím tắt chuyển chế độ Sáng/Tối.