### PR TITLE
Feature/23.12.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## ZaDark 23.12.4
+> PC 12.2 và Web 9.19
+
+### Fixed
+- Sửa lỗi Ẩn tên cuộc trò chuyện Cộng đồng
+
 ## ZaDark 23.12.3
 > PC 12.1 và Web 9.18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 > PC 12.2 và Web 9.19
 
 ### Fixed
-- Sửa lỗi Ẩn tên cuộc trò chuyện Cộng đồng
+- Sửa lỗi Ẩn tên cuộc trò chuyện "Cộng đồng" ([#97](https://github.com/quaric/zadark/issues/97))
+- Sửa lỗi Dark Mode giao diện "Gửi lời mời kết bạn" ([#96](https://github.com/quaric/zadark/issues/96))
 
 ## ZaDark 23.12.3
 > PC 12.1 và Web 9.18

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadark",
   "description": "Dark Mode tốt nhất cho Zalo",
-  "version": "23.12.3",
+  "version": "23.12.4",
   "repository": "https://github.com/quaric/zadark.git",
   "author": {
     "name": "Quaric",

--- a/src/core/scss/_zadark-prv.scss
+++ b/src/core/scss/_zadark-prv.scss
@@ -252,6 +252,7 @@
       transition: opacity 100ms ease-in-out;
     }
 
+    .community__conv-indicator,
     .truncate {
       opacity: 0;
       transition: opacity 100ms ease-in-out;
@@ -266,6 +267,7 @@
       opacity: 0;
     }
 
+    .community__conv-indicator,
     .truncate {
       opacity: 1;
     }

--- a/src/core/scss/zadark.scss
+++ b/src/core/scss/zadark.scss
@@ -1404,6 +1404,10 @@ html[data-zadark-theme="dark"] {
 
     // END: Image Show
 
+    .friend-profile__addfriend {
+      background-color: var(--WA100) !important;
+    }
+
     .friend-profile__addfriend__msg {
       background: transparent;
     }

--- a/src/pc/package.json
+++ b/src/pc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadark-pc",
   "description": "Dark Mode tốt nhất cho Zalo",
-  "version": "12.1",
+  "version": "12.2",
   "main": "index.js",
   "repository": "https://github.com/quaric/zadark.git",
   "author": {

--- a/src/web/vendor/chrome/manifest.json
+++ b/src/web/vendor/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ZaDark – Zalo Dark Mode",
-  "version": "9.18",
+  "version": "9.19",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "Quaric",

--- a/src/web/vendor/edge/manifest.json
+++ b/src/web/vendor/edge/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ZaDark – Zalo Dark Mode",
-  "version": "9.18",
+  "version": "9.19",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "Quaric",

--- a/src/web/vendor/firefox/manifest.json
+++ b/src/web/vendor/firefox/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "ZaDark – Zalo Dark Mode",
-  "version": "9.18",
+  "version": "9.19",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "Quaric",

--- a/src/web/vendor/opera/manifest.json
+++ b/src/web/vendor/opera/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ZaDark – Zalo Dark Mode",
-  "version": "9.18",
+  "version": "9.19",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "Quaric",

--- a/src/web/vendor/safari/manifest.json
+++ b/src/web/vendor/safari/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "ZaDark for Safari",
-  "version": "9.18",
+  "version": "9.19",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "Quaric",


### PR DESCRIPTION
## ZaDark 23.12.4
> PC 12.2 và Web 9.19

### Fixed
- Sửa lỗi Ẩn tên cuộc trò chuyện "Cộng đồng" ([#97](https://github.com/quaric/zadark/issues/97))
- Sửa lỗi Dark Mode giao diện "Gửi lời mời kết bạn" ([#96](https://github.com/quaric/zadark/issues/96))