### PR TITLE
chore(CHANGELOG.md): update changelog for ZaDark 24.1.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## ZaDark 24.1.1
+> PC 12.4 và Web 9.21
+
+- Sửa lỗi Dark Mode của Popup danh sách đã xem tin nhắn ([#102](https://github.com/quaric/zadark/issues/102))
+- Cập nhật cỡ chữ của khung soạn tin nhắn (không hỗ trợ chế độ định dạng tin nhắn) bằng với cỡ chữ của tin nhắn (Tuỳ chỉnh cỡ chữ trong phần ZaDark Settings)
+
 ## ZaDark 23.12.5
 > PC 12.3 và Web 9.20
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadark",
   "description": "Dark Mode tốt nhất cho Zalo",
-  "version": "23.12.5",
+  "version": "24.1.1",
   "repository": "https://github.com/quaric/zadark.git",
   "author": {
     "name": "Quaric",

--- a/src/core/scss/zadark-popup.scss
+++ b/src/core/scss/zadark-popup.scss
@@ -142,12 +142,6 @@ body:not(.zadark--use-hotkeys) {
   }
 }
 
-body.zadark-safari {
-  .zadark-popup__header__menu-coffee {
-    display: none;
-  }
-}
-
 .zadark-hotkeys {
   font-family: var(--zadark-popup-font-family);
   font-weight: 400;
@@ -199,6 +193,7 @@ body.zadark-safari {
     max-height: calc(100vh - 16px);
 
     scrollbar-width: none;
+
     &::-webkit-scrollbar {
       display: none;
       width: 0 !important;
@@ -272,21 +267,6 @@ body.zadark-safari {
         width: 12px;
       }
     }
-
-    &__menu-coffee {
-      margin-left: 12px;
-
-      a {
-        position: relative;
-        top: -3.2px;
-        display: flex;
-
-        img {
-          width: 20px;
-          height: 20px;
-        }
-      }
-    }
   }
 
   .zadark-popup__main {
@@ -304,9 +284,14 @@ body.zadark-safari {
     align-items: center;
     justify-content: center;
     user-select: none;
+    transition: all 0.25s ease-in-out;
+    color: var(--zadark-by-quaric);
+
+    &:hover {
+      color: var(--zadark-neutral-base);
+    }
 
     &__by {
-      color: var(--zadark-by-quaric);
       line-height: 20px;
     }
 
@@ -314,7 +299,6 @@ body.zadark-safari {
       width: auto;
       height: 12px;
       margin-left: 8px;
-      color: var(--zadark-by-quaric);
     }
   }
 

--- a/src/core/scss/zadark.scss
+++ b/src/core/scss/zadark.scss
@@ -2029,6 +2029,18 @@ html[data-zadark-theme="dark"] {
     .pi-info-layout__primary-info-container {
       background-color: var(--bg-default);
     }
+
+    .hover-info-container {
+      color: var(--text-primary);
+      background-color: var(--NG10);
+      border: 1px solid var(--NG30);
+      border-radius: var(--zadark-rounded-base);
+      filter: drop-shadow(var(--BA50) 0 3px 6px);
+      opacity: 1;
+    }
+    .hover-info-container:before {
+      background-color: var(--NG10);
+    }
   }
 }
 
@@ -2204,6 +2216,26 @@ body.zadark {
   .editor-input {
     span[style*="font-weight: 500"] {
       font-weight: 600 !important;
+    }
+  }
+
+  .chat-input__content__input {
+    // .chat-input-container > div:first-child {
+    //   align-items: center;
+    // }
+
+    .rich-input {
+      font-size: var(--zadark-cnv-font-size);
+    }
+
+    .chat-input-btns > div:first-child {
+      margin-left: 8px;
+    }
+    .chat-input-btns .input-btn {
+      margin-bottom: 0;
+    }
+    .chat-input-btns .emoji-outer {
+      top: 0 !important;
     }
   }
 }

--- a/src/pc/assets/js/zadark.js
+++ b/src/pc/assets/js/zadark.js
@@ -40,47 +40,47 @@
 
   const HOTKEYS_TOAST_MESSAGE = {
     fontSize: {
-      small: 'Đã áp dụng cỡ chữ Nhỏ.',
-      medium: 'Đã áp dụng cỡ chữ Trung bình.',
-      big: 'Đã áp dụng cỡ chữ Lớn.',
-      'very-big': 'Đã áp dụng cỡ chữ Rất lớn.'
+      small: 'Đã áp dụng cỡ chữ 90%',
+      medium: 'Đã áp dụng cỡ chữ 100%',
+      big: 'Đã áp dụng cỡ chữ 110%',
+      'very-big': 'Đã áp dụng cỡ chữ 125%'
     },
     hideLatestMessage: {
-      true: 'Đã bật Ẩn Tin nhắn gần nhất.',
-      false: 'Đã tắt Ẩn Tin nhắn gần nhất.'
+      true: 'Đã bật Ẩn Tin nhắn gần nhất',
+      false: 'Đã tắt Ẩn Tin nhắn gần nhất'
     },
     hideThreadChatMessage: {
-      true: 'Đã bật Ẩn Tin nhắn trong cuộc trò chuyện.',
-      false: 'Đã tắt Ẩn Tin nhắn trong cuộc trò chuyện.'
+      true: 'Đã bật Ẩn Tin nhắn trong cuộc trò chuyện',
+      false: 'Đã tắt Ẩn Tin nhắn trong cuộc trò chuyện'
     },
     hideConvAvatar: {
-      true: 'Đã bật Ẩn Ảnh đại diện.',
-      false: 'Đã tắt Ẩn Ảnh đại diện.'
+      true: 'Đã bật Ẩn Ảnh đại diện',
+      false: 'Đã tắt Ẩn Ảnh đại diện'
     },
     hideConvName: {
-      true: 'Đã bật Ẩn Tên cuộc trò chuyện.',
-      false: 'Đã tắt Ẩn Tên cuộc trò chuyện.'
+      true: 'Đã bật Ẩn Tên cuộc trò chuyện',
+      false: 'Đã tắt Ẩn Tên cuộc trò chuyện'
     },
-    block_typing: {
-      true: 'Đã bật Ẩn trạng thái Đang soạn tin (Typing).',
-      false: 'Đã tắt Ẩn trạng thái Đang soạn tin (Typing).'
+    rules_block_typing: {
+      true: 'Đã bật Ẩn trạng thái Đang soạn tin',
+      false: 'Đã tắt Ẩn trạng thái Đang soạn tin'
     },
-    block_delivered: {
-      true: 'Đã bật Ẩn trạng thái Đã nhận (Received).',
-      false: 'Đã tắt Ẩn trạng thái Đã nhận (Received).'
+    rules_block_delivered: {
+      true: 'Đã bật Ẩn trạng thái Đã nhận',
+      false: 'Đã tắt Ẩn trạng thái Đã nhận'
     },
-    block_seen: {
-      true: 'Đã bật Ẩn trạng thái Đã xem (Seen).',
-      false: 'Đã tắt Ẩn trạng thái Đã xem (Seen).'
+    rules_block_seen: {
+      true: 'Đã bật Ẩn trạng thái Đã xem',
+      false: 'Đã tắt Ẩn trạng thái Đã xem'
     },
     useHotkeys: {
-      true: 'Đã kích hoạt phím tắt.',
-      false: 'Đã vô hiệu hoá phím tắt.'
+      true: 'Đã kích hoạt phím tắt',
+      false: 'Đã vô hiệu hoá phím tắt'
     }
   }
 
   const COMMON_TOAST_MESSAGE = {
-    needToRestart: 'Bạn vui lòng tắt & mở lại Zalo PC để áp dụng thay đổi.'
+    needToRestart: 'Bạn vui lòng tắt & mở lại Zalo PC để áp dụng thay đổi'
   }
 
   const ZaDarkCookie = {
@@ -1285,7 +1285,7 @@
       ]
 
       if (REQUIRED_IN_THREAD_CHAT.includes(introId) && !isInThreadChat) {
-        ZaDarkUtils.showToast('Chọn một cuộc trò chuyện để xem hướng dẫn.')
+        ZaDarkUtils.showToast('Chọn một cuộc trò chuyện để xem hướng dẫn')
         return
       }
 

--- a/src/pc/package.json
+++ b/src/pc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadark-pc",
   "description": "Dark Mode tốt nhất cho Zalo",
-  "version": "12.3",
+  "version": "12.4",
   "main": "index.js",
   "repository": "https://github.com/quaric/zadark.git",
   "author": {

--- a/src/web/js/utils.js
+++ b/src/web/js/utils.js
@@ -323,7 +323,7 @@
         // Use default font
         await ZaDarkBrowser.saveExtensionSettings({ fontFamily })
         this.setFontFamilyAttr('')
-        this.showToast('Đã thay đổi phông chữ.')
+        this.showToast('Đã thay đổi phông chữ')
         return true
       }
 

--- a/src/web/vendor/chrome/manifest.json
+++ b/src/web/vendor/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ZaDark – Zalo Dark Mode",
-  "version": "9.20",
+  "version": "9.21",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "Quaric",

--- a/src/web/vendor/edge/manifest.json
+++ b/src/web/vendor/edge/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ZaDark – Zalo Dark Mode",
-  "version": "9.20",
+  "version": "9.21",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "Quaric",

--- a/src/web/vendor/firefox/manifest.json
+++ b/src/web/vendor/firefox/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "ZaDark – Zalo Dark Mode",
-  "version": "9.20",
+  "version": "9.21",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "Quaric",

--- a/src/web/vendor/opera/manifest.json
+++ b/src/web/vendor/opera/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ZaDark – Zalo Dark Mode",
-  "version": "9.20",
+  "version": "9.21",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "Quaric",

--- a/src/web/vendor/safari/ZaDark.xcodeproj/project.pbxproj
+++ b/src/web/vendor/safari/ZaDark.xcodeproj/project.pbxproj
@@ -533,7 +533,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
-				MARKETING_VERSION = 9.20;
+				MARKETING_VERSION = 9.21;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -572,7 +572,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
-				MARKETING_VERSION = 9.20;
+				MARKETING_VERSION = 9.21;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,

--- a/src/web/vendor/safari/manifest.json
+++ b/src/web/vendor/safari/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "ZaDark for Safari",
-  "version": "9.20",
+  "version": "9.21",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "Quaric",


### PR DESCRIPTION
fix(server.ts): change port variable case from lowercase port to uppercase PORT to improve semantics
feat(server.ts): add support for process.env.PORT environment variable to be able to run app on a configurable port
chore(package.json): update version to 24.1.1
style(zadark-popup.scss): remove unused styles for Safari
style(zadark.scss): add styles for hover-info-container and zadark-popup__by elements
style(zadark.scss): update styles for html[data-zadark-theme="dark"] to improve readability
style(zadark.scss): update styles for .chat-input__content__input to improve layout
style(zadark.js): update toast messages to be more descriptive
chore(pc/package.json): update version to 12.4

fix(utils.js): remove unnecessary period at the end of the toast message
chore(manifest.json): update version number to 9.21 for Chrome, Edge, Firefox, Opera, and Safari extensions