### PR TITLE
Feature/24.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## ZaDark 24.2.2
+> PC 12.7 và Web 9.24
+
+- Sửa lỗi Dark Mode: Sticker mùa lễ hội
+
 ## ZaDark 24.2.1
 > PC 12.6 và Web 9.23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 > PC 12.7 và Web 9.24
 
 - Sửa lỗi Dark Mode: Sticker mùa lễ hội
+- Cho phép tắt dịch tin nhắn
 
 ## ZaDark 24.2.1
 > PC 12.6 và Web 9.23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 - Sửa lỗi Dark Mode: Sticker mùa lễ hội
 - Cho phép tắt dịch tin nhắn
+- Thêm giải thích khi chọn ngôn ngữ
 - Tối ưu mã nguồn
 
 ## ZaDark 24.2.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 - Sửa lỗi Dark Mode: Sticker mùa lễ hội
 - Cho phép tắt dịch tin nhắn
+- Tối ưu mã nguồn
 
 ## ZaDark 24.2.1
 > PC 12.6 và Web 9.23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 - Sửa lỗi Dark Mode: Sticker mùa lễ hội
 - Cho phép tắt dịch tin nhắn
+- Hỗ trợ dịch tin nhắn có hình ảnh
 - Thêm giải thích khi chọn ngôn ngữ
 - Tối ưu mã nguồn
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 > PC 12.7 và Web 9.24
 
 - Sửa lỗi Dark Mode: Sticker mùa lễ hội
+- Sửa lỗi Dark Mode: Double Click vào tin nhắn hình ảnh
 - Cho phép tắt dịch tin nhắn
 - Hỗ trợ dịch tin nhắn có hình ảnh
 - Thêm giải thích khi chọn ngôn ngữ

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadark",
   "description": "Dark Mode tốt nhất cho Zalo",
-  "version": "24.2.1",
+  "version": "24.2.2",
   "repository": "https://github.com/quaric/zadark.git",
   "author": {
     "name": "Quaric",

--- a/src/core/js/zadark-translate.js
+++ b/src/core/js/zadark-translate.js
@@ -95,19 +95,19 @@
 
     return this.each(function () {
       $(this).on('mouseenter.zadark-translate-msg', '.card.card--text', function (e) {
-        const $cardEl = $(this)
-        const $contentEl = $cardEl
-        const $textEl = $contentEl.find('div > span-15')
+        const $card = $(this)
+        const $content = $card
+        const $text = $content.find('div > span-15')
 
-        addTranslateListener($cardEl, $contentEl, $textEl, translateTarget)
+        addTranslateListener($card, $content, $text, translateTarget)
       })
 
       $(this).on('mouseenter.zadark-translate-msg', '.chatImageMessage', function (e) {
-        const $cardEl = $(this).find('.img-msg-v2__ft')
-        const $contentEl = $(this).find('.img-msg-v2__cap')
-        const $textEl = $contentEl.find('span-15')
+        const $card = $(this).find('.img-msg-v2__ft')
+        const $content = $(this).find('.img-msg-v2__cap')
+        const $text = $content.find('span-15')
 
-        addTranslateListener($cardEl, $contentEl, $textEl, translateTarget)
+        addTranslateListener($card, $content, $text, translateTarget)
       })
     })
   }

--- a/src/core/js/zadark-translate.js
+++ b/src/core/js/zadark-translate.js
@@ -54,6 +54,10 @@
 
           const translateTarget = typeof getTargetLanguage === 'function' ? getTargetLanguage() : 'vi'
 
+          if (!translateTarget) {
+            return
+          }
+
           const nextTranslationEl = $('<div>')
             .addClass('zadark-translate__content')
             .html(`
@@ -641,6 +645,8 @@
       const selectElement = $(this)
 
       selectElement.empty()
+
+      selectElement.append($('<option>').val('none').text('Tắt'))
 
       LANGUAGES.forEach(function (language) {
         const option = $('<option>').val(language.code).text(`Tiếng ${language.name}`)

--- a/src/core/js/zadark-translate.js
+++ b/src/core/js/zadark-translate.js
@@ -21,6 +21,73 @@
     }
   }
 
+  /**
+   *
+   * @param {jQuery} $buttonWrapper Element will have "translation button" added.
+   * @param {jQuery} $resultWrapper Element will have "translated content" added.
+   * @param {jQuery} $text Element contains the message content to be translated.
+   * @param {string} translateTarget Language to be translated into.
+   * @returns
+   */
+  const addTranslateListener = ($buttonWrapper, $resultWrapper, $text, translateTarget) => {
+    if ($buttonWrapper.find('.zadark-translate-msg__button').length) {
+      return
+    }
+
+    const text = $text ? $text.text().replace(/(?:\r\n|\r|\n)/g, '<br>') : ''
+
+    const $button = $('<button>')
+      .addClass('zadark-translate-msg__button')
+      .html('<i class="zadark-icon zadark-icon--translate"></i>')
+
+    $button.on('click', function (e) {
+      e.preventDefault()
+      e.stopPropagation()
+
+      const $prevTranslation = $resultWrapper.find('.zadark-translate-msg__content')
+
+      if ($prevTranslation.length) {
+        $prevTranslation.remove()
+        return
+      }
+
+      if (!text) {
+        return
+      }
+
+      const $nextTranslation = $('<div>')
+        .addClass('zadark-translate-msg__content')
+        .html(`
+            <div class="zadark-translate-msg__content__title">
+              <i class="zadark-icon zadark-icon--translate"></i>
+              Đang dịch ...
+            </div>
+          `)
+
+      $resultWrapper.append($nextTranslation)
+
+      translate(text, translateTarget).then((res) => {
+        if (!res.success) {
+          $nextTranslation
+            .addClass('zadark-translate-msg__content--error')
+            .html('Lỗi: ' + res.message)
+          return
+        }
+
+        $nextTranslation
+          .html(`
+              <div class="zadark-translate-msg__content__title">
+                <i class="zadark-icon zadark-icon--translate"></i>
+                ${res.languageName}
+              </div>
+              <div>${res.translation}</div>
+            `)
+      })
+    })
+
+    $buttonWrapper.append($button)
+  }
+
   $.fn.enableTranslateMessage = function (translateTarget) {
     if (!translateTarget || translateTarget === 'none') {
       return
@@ -29,64 +96,18 @@
     return this.each(function () {
       $(this).on('mouseenter.zadark-translate-msg', '.card.card--text', function (e) {
         const $cardEl = $(this)
+        const $contentEl = $cardEl
+        const $textEl = $contentEl.find('div > span-15')
 
-        if ($cardEl.find('.zadark-translate-msg__button').length) {
-          return
-        }
+        addTranslateListener($cardEl, $contentEl, $textEl, translateTarget)
+      })
 
-        const $textEl = $cardEl.find('div > span-15')
-        const text = $textEl ? $textEl.text().replace(/(?:\r\n|\r|\n)/g, '<br>') : ''
+      $(this).on('mouseenter.zadark-translate-msg', '.chatImageMessage', function (e) {
+        const $cardEl = $(this).find('.img-msg-v2__ft')
+        const $contentEl = $(this).find('.img-msg-v2__cap')
+        const $textEl = $contentEl.find('span-15')
 
-        const $buttonEl = $('<button>')
-          .addClass('zadark-translate-msg__button')
-          .html('<i class="zadark-icon zadark-icon--translate"></i>')
-
-        $buttonEl.on('click', function (e) {
-          e.preventDefault()
-          e.stopPropagation()
-
-          const $prevTranslateEl = $cardEl.find('.zadark-translate-msg__content')
-
-          if ($prevTranslateEl.length) {
-            $prevTranslateEl.remove()
-            return
-          }
-
-          if (!text) {
-            return
-          }
-
-          const $nextTranslationEl = $('<div>')
-            .addClass('zadark-translate-msg__content')
-            .html(`
-              <div class="zadark-translate-msg__content__title">
-                <i class="zadark-icon zadark-icon--translate"></i>
-                Đang dịch ...
-              </div>
-            `)
-
-          $cardEl.append($nextTranslationEl)
-
-          translate(text, translateTarget).then((res) => {
-            if (!res.success) {
-              $nextTranslationEl
-                .addClass('zadark-translate-msg__content--error')
-                .html('Lỗi: ' + res.message)
-              return
-            }
-
-            $nextTranslationEl
-              .html(`
-                <div class="zadark-translate-msg__content__title">
-                  <i class="zadark-icon zadark-icon--translate"></i>
-                  ${res.languageName}
-                </div>
-                <div>${res.translation}</div>
-              `)
-          })
-        })
-
-        $cardEl.append($buttonEl)
+        addTranslateListener($cardEl, $contentEl, $textEl, translateTarget)
       })
     })
   }

--- a/src/core/js/zadark-translate.js
+++ b/src/core/js/zadark-translate.js
@@ -21,30 +21,34 @@
     }
   }
 
-  $.fn.zadarkTranslateMessage = function (getTargetLanguage) {
-    return this.each(function () {
-      $(this).on('mouseenter', '.card.card--text', function (e) {
-        const cardEl = $(this)
+  $.fn.enableTranslateMessage = function (translateTarget) {
+    if (!translateTarget || translateTarget === 'none') {
+      return
+    }
 
-        if (cardEl.find('.zadark-translate__button').length) {
+    return this.each(function () {
+      $(this).on('mouseenter.zadark-translate-msg', '.card.card--text', function (e) {
+        const $cardEl = $(this)
+
+        if ($cardEl.find('.zadark-translate-msg__button').length) {
           return
         }
 
-        const textEl = cardEl.find('div > span-15')
-        const text = textEl ? textEl.text().replace(/(?:\r\n|\r|\n)/g, '<br>') : ''
+        const $textEl = $cardEl.find('div > span-15')
+        const text = $textEl ? $textEl.text().replace(/(?:\r\n|\r|\n)/g, '<br>') : ''
 
-        const buttonEl = $('<button>')
-          .addClass('zadark-translate__button')
+        const $buttonEl = $('<button>')
+          .addClass('zadark-translate-msg__button')
           .html('<i class="zadark-icon zadark-icon--translate"></i>')
 
-        buttonEl.on('click', function (e) {
+        $buttonEl.on('click', function (e) {
           e.preventDefault()
           e.stopPropagation()
 
-          const prevTranslateEl = cardEl.find('.zadark-translate__content')
+          const $prevTranslateEl = $cardEl.find('.zadark-translate-msg__content')
 
-          if (prevTranslateEl.length) {
-            prevTranslateEl.remove()
+          if ($prevTranslateEl.length) {
+            $prevTranslateEl.remove()
             return
           }
 
@@ -52,34 +56,28 @@
             return
           }
 
-          const translateTarget = typeof getTargetLanguage === 'function' ? getTargetLanguage() : 'vi'
-
-          if (!translateTarget) {
-            return
-          }
-
-          const nextTranslationEl = $('<div>')
-            .addClass('zadark-translate__content')
+          const $nextTranslationEl = $('<div>')
+            .addClass('zadark-translate-msg__content')
             .html(`
-              <div class="zadark-translate__content__title">
+              <div class="zadark-translate-msg__content__title">
                 <i class="zadark-icon zadark-icon--translate"></i>
                 Đang dịch ...
               </div>
             `)
 
-          cardEl.append(nextTranslationEl)
+          $cardEl.append($nextTranslationEl)
 
           translate(text, translateTarget).then((res) => {
             if (!res.success) {
-              nextTranslationEl
-                .addClass('zadark-translate__content--error')
+              $nextTranslationEl
+                .addClass('zadark-translate-msg__content--error')
                 .html('Lỗi: ' + res.message)
               return
             }
 
-            nextTranslationEl
+            $nextTranslationEl
               .html(`
-                <div class="zadark-translate__content__title">
+                <div class="zadark-translate-msg__content__title">
                   <i class="zadark-icon zadark-icon--translate"></i>
                   ${res.languageName}
                 </div>
@@ -88,8 +86,18 @@
           })
         })
 
-        cardEl.append(buttonEl)
+        $cardEl.append($buttonEl)
       })
+    })
+  }
+
+  $.fn.disableTranslateMessage = function () {
+    return this.each(function () {
+      // Remove event listener
+      $(this).off('mouseenter.zadark-translate-msg')
+
+      // Remove translate button
+      $(this).find('.zadark-translate-msg__button').remove()
     })
   }
 
@@ -642,18 +650,17 @@
 
   $.fn.setLanguagesOptions = function (defaultLanguage = 'vi') {
     return this.each(function () {
-      const selectElement = $(this)
+      const $selectEl = $(this)
 
-      selectElement.empty()
-
-      selectElement.append($('<option>').val('none').text('Tắt'))
+      $selectEl.empty()
+      $selectEl.append($('<option>').val('none').text('Tắt'))
 
       LANGUAGES.forEach(function (language) {
         const option = $('<option>').val(language.code).text(`Tiếng ${language.name}`)
-        selectElement.append(option)
+        $selectEl.append(option)
       })
 
-      selectElement.val(defaultLanguage)
+      $selectEl.val(defaultLanguage)
     })
   }
 })(jQuery)

--- a/src/core/scss/_zadark-translate.scss
+++ b/src/core/scss/_zadark-translate.scss
@@ -1,0 +1,76 @@
+@mixin translate-message {
+  .zadark-translate-msg__button {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    z-index: 3;
+
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+
+    padding: 0;
+    margin: 0;
+    transform: translate(-50%, 50%);
+
+    border: 1px solid var(--zadark-primary-dark);
+    border-radius: 32px;
+    box-shadow: 0 0 4px rgba(0, 0, 0, 0.25);
+
+    background-color: var(--zadark-primary-base);
+    opacity: 0;
+    cursor: pointer;
+
+    .zadark-icon {
+      color: #fff;
+      font-size: 18px;
+    }
+  }
+
+  .card--text:hover {
+    .zadark-translate-msg__button {
+      opacity: 1;
+    }
+  }
+
+  .zadark-translate-msg__content {
+    margin-top: 10px;
+    padding: 12px;
+
+    border: 1px solid var(--white-message-border);
+    border-radius: var(--zadark-rounded-base);
+
+    background: var(--white-quote);
+    font-size: 0.875rem;
+
+    &__title {
+      color: var(--text-quote);
+      user-select: none;
+    }
+
+    &__title + div {
+      margin-top: 4px;
+    }
+
+    &--error {
+      border-color: var(--error-border) !important;
+      background: transparent !important;
+      color: var(--text-errors) !important;
+    }
+
+    .zadark-icon {
+      position: relative;
+      top: 2px;
+      font-size: 16px;
+    }
+  }
+
+  .card--text.me {
+    .zadark-translate-msg__content {
+      border-color: var(--blue-message-border);
+      background: var(--blue-quote);
+    }
+  }
+}

--- a/src/core/scss/_zadark-translate.scss
+++ b/src/core/scss/_zadark-translate.scss
@@ -29,7 +29,8 @@
     }
   }
 
-  .card--text:hover {
+  .card--text:hover,
+  .chatImageMessage:hover {
     .zadark-translate-msg__button {
       opacity: 1;
     }
@@ -67,7 +68,8 @@
     }
   }
 
-  .card--text.me {
+  .card--text.me,
+  .chatImageMessage.-me {
     .zadark-translate-msg__content {
       border-color: var(--blue-message-border);
       background: var(--blue-quote);

--- a/src/core/scss/zadark-popup.scss
+++ b/src/core/scss/zadark-popup.scss
@@ -191,7 +191,6 @@ body:not(.zadark--use-hotkeys) {
     overflow-y: auto;
 
     max-height: calc(100vh - 16px);
-
     scrollbar-width: none;
 
     &::-webkit-scrollbar {
@@ -622,6 +621,7 @@ body:not(.zadark--use-hotkeys) {
         margin-left: 2px;
         color: var(--zadark-neutral-600);
         font-size: 0.875rem;
+        cursor: pointer;
       }
     }
 
@@ -659,7 +659,7 @@ body:not(.zadark--use-hotkeys) {
 
   #js-btn-scroll {
     position: fixed;
-    bottom: 12px;
+    bottom: 8px;
     left: 50%;
 
     width: 32px;

--- a/src/core/scss/zadark.scss
+++ b/src/core/scss/zadark.scss
@@ -4,6 +4,7 @@
 */
 
 @use "zadark-prv" as prv;
+@use "zadark-translate" as translate;
 
 @mixin zadark-colors {
   // Neutral
@@ -2151,6 +2152,8 @@ body.zadark {
     position: absolute;
     z-index: 9999;
 
+    inset: auto auto 8px 64px;
+
     display: none;
     width: 480px;
     max-height: 100%;
@@ -2161,12 +2164,12 @@ body.zadark {
 
     #zadark-popup {
       overflow: hidden;
-      margin-bottom: 8px;
       border-radius: var(--zadark-rounded-base);
       box-shadow: var(--popper-shadow);
 
       #js-btn-scroll {
-        bottom: 20px; // 8px + 12px
+        bottom: 16px;
+        left: 304px; // 240px + 64px
       }
     }
   }
@@ -2260,78 +2263,5 @@ body.zadark {
     }
   }
 
-  .zadark-translate__button {
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    z-index: 3;
-
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 32px;
-    height: 32px;
-
-    padding: 0;
-    margin: 0;
-    transform: translate(-50%, 50%);
-
-    border: 1px solid var(--zadark-primary-dark);
-    border-radius: 32px;
-    box-shadow: 0 0 4px rgba(0, 0, 0, 0.25);
-
-    background-color: var(--zadark-primary-base);
-    opacity: 0;
-    cursor: pointer;
-
-    .zadark-icon {
-      color: #fff;
-      font-size: 18px;
-    }
-  }
-
-  .card--text:hover {
-    .zadark-translate__button {
-      opacity: 1;
-    }
-  }
-
-  .zadark-translate__content {
-    margin-top: 10px;
-    padding: 12px;
-
-    border: 1px solid var(--white-message-border);
-    border-radius: var(--zadark-rounded-base);
-
-    background: var(--white-quote);
-    font-size: 0.875rem;
-
-    &__title {
-      color: var(--text-quote);
-      user-select: none;
-    }
-
-    &__title + div {
-      margin-top: 4px;
-    }
-
-    .zadark-icon {
-      position: relative;
-      top: 2px;
-      font-size: 16px;
-    }
-
-    &--error {
-      border-color: var(--error-border) !important;
-      background: transparent !important;
-      color: var(--text-errors) !important;
-    }
-  }
-
-  .card--text.me {
-    .zadark-translate__content {
-      border-color: var(--blue-message-border);
-      background: var(--blue-quote);
-    }
-  }
+  @include translate.translate-message();
 }

--- a/src/core/scss/zadark.scss
+++ b/src/core/scss/zadark.scss
@@ -897,6 +897,9 @@ html[data-zadark-theme="dark"] {
     .img-msg-v2:not(.-caption).-highlight {
       background-color: transparent;
     }
+    .img-msg-v2.-caption.-highlight > .img-msg-v2__bub > .img-msg-v2__ft {
+      background-color: var(--blue-message-selected);
+    }
 
     .sticker-selector__menu {
       height: 48px;

--- a/src/core/scss/zadark.scss
+++ b/src/core/scss/zadark.scss
@@ -2056,6 +2056,12 @@ html[data-zadark-theme="dark"] {
         }
       }
     }
+
+    // Seasonal
+    .fss-preview-volume,
+    .seasonal-item-preview > i {
+      color: #fff;
+    }
   }
 }
 

--- a/src/pc/assets/js/zadark.js
+++ b/src/pc/assets/js/zadark.js
@@ -267,14 +267,6 @@
       document.documentElement.setAttribute('data-zadark-font-size', fontSize)
     },
 
-    setTranslateTargetAttr: (translateTarget) => {
-      document.documentElement.setAttribute('data-zadark-trans-target', translateTarget)
-    },
-
-    getTranslateTargetAttr: (translateTarget) => {
-      return document.documentElement.getAttribute('data-zadark-trans-target') || 'vi'
-    },
-
     setHideLatestMessageAttr: function (isEnabled) {
       this.toggleBodyClassName('zadark-prv--latest-message', isEnabled)
     },
@@ -434,9 +426,6 @@
       const fontSize = ZaDarkStorage.getFontSize()
       this.setFontSizeAttr(fontSize)
 
-      const translateTarget = ZaDarkStorage.getTranslateTarget()
-      this.setTranslateTargetAttr(translateTarget)
-
       const enabledHideLatestMessage = ZaDarkStorage.getEnabledHideLatestMessage()
       this.setHideLatestMessageAttr(enabledHideLatestMessage)
 
@@ -494,7 +483,6 @@
 
     updateTranslateTarget: function (translateTarget) {
       ZaDarkStorage.saveTranslateTarget(translateTarget)
-      this.setTranslateTargetAttr(translateTarget)
     },
 
     updateHideLatestMessage: function (isEnabled) {
@@ -632,11 +620,6 @@
     })
   }
 
-  function handleThemeChange () {
-    const theme = $(this).val()
-    ZaDarkUtils.updateTheme(theme)
-  }
-
   const handleNextTheme = () => {
     const theme = ZaDarkStorage.getTheme()
 
@@ -664,11 +647,6 @@
     }
   }
 
-  function handleFontSizeChange () {
-    const fontSize = $(this).val()
-    ZaDarkUtils.updateFontSize(fontSize)
-  }
-
   const handleNextFontSize = (count) => {
     const fontSize = ZaDarkStorage.getFontSize()
 
@@ -681,32 +659,7 @@
     const nextFontSize = fontSizes[nextIndex]
 
     ZaDarkUtils.setSelect(selectFontSizeElName, nextFontSize)
-    handleFontSizeChange.bind($(selectFontSizeElName))()
-  }
-
-  function handleTranslateTargetChange () {
-    const translateTarget = $(this).val()
-    ZaDarkUtils.updateTranslateTarget(translateTarget)
-  }
-
-  function handleHideLastestMessageChange () {
-    const isEnabled = $(this).is(':checked')
-    ZaDarkUtils.updateHideLatestMessage(isEnabled)
-  }
-
-  function handleHideConvAvatarChange () {
-    const isEnabled = $(this).is(':checked')
-    ZaDarkUtils.updateHideConvAvatar(isEnabled)
-  }
-
-  function handleHideConvNameChange () {
-    const isEnabled = $(this).is(':checked')
-    ZaDarkUtils.updateHideConvName(isEnabled)
-  }
-
-  function handleHideThreadChatMessageChange () {
-    const isEnabled = $(this).is(':checked')
-    ZaDarkUtils.updateHideThreadChatMessage(isEnabled)
+    ZaDarkUtils.updateFontSize(nextFontSize)
   }
 
   const handleBlockSettingsChange = (blockId) => {
@@ -722,12 +675,6 @@
       const isEnabled = $(this).is(':checked')
       ZaDarkUtils.updateBlockSettings(blockId, isEnabled)
     }
-  }
-
-  function handleUseHotkeysChange () {
-    const useHotkeys = $(this).is(':checked')
-    ZaDarkUtils.updateUseHotkeys(useHotkeys)
-    loadHotkeys(useHotkeys)
   }
 
   function disableFeatureBlock () {
@@ -838,6 +785,11 @@
               <i class="zadark-icon zadark-icon--question" data-tippy-content='Bạn di chuyển chuột vào đoạn tin nhắn<br/>và chọn biểu tượng <i class="zadark-icon zadark-icon--translate" style="position: relative; top: 3px; font-size: 18px;"></i> để dịch tin nhắn.'></i>
               <span class="zadark-beta"></span>
             </label>
+
+            <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" style="margin-right: 8px; color: var(--zadark-neutral-600);">
+              <path d="M0 0h24v24H0V0z" fill="none"></path>
+              <path d="M5 13h11.17l-4.88 4.88c-.39.39-.39 1.03 0 1.42.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41l-6.58-6.6c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L16.17 11H5c-.55 0-1 .45-1 1s.45 1 1 1z" fill="currentColor"></path>
+            </svg>
 
             <select id="js-select-translate-target" class="zadark-select"></select>
           </div>
@@ -1049,7 +1001,7 @@
         case 'command+1':
         case 'ctrl+1': {
           ZaDarkUtils.setSwitch(switchHideLatestMessageElName, !enabledHideLatestMessage)
-          handleHideLastestMessageChange.bind($(switchHideLatestMessageElName))()
+          ZaDarkUtils.updateHideLatestMessage(!enabledHideLatestMessage)
           return
         }
 
@@ -1057,7 +1009,7 @@
         case 'command+2':
         case 'ctrl+2': {
           ZaDarkUtils.setSwitch(switchHideThreadChatMessageElName, !enabledHideThreadChatMessage)
-          handleHideThreadChatMessageChange.bind($(switchHideThreadChatMessageElName))()
+          ZaDarkUtils.updateHideThreadChatMessage(!enabledHideThreadChatMessage)
           return
         }
 
@@ -1065,7 +1017,7 @@
         case 'command+3':
         case 'ctrl+3': {
           ZaDarkUtils.setSwitch(switchHideConvAvatarElName, !enabledHideConvAvatar)
-          handleHideConvAvatarChange.bind($(switchHideConvAvatarElName))()
+          ZaDarkUtils.updateHideConvAvatar(!enabledHideConvAvatar)
           return
         }
 
@@ -1073,7 +1025,7 @@
         case 'command+7':
         case 'ctrl+7': {
           ZaDarkUtils.setSwitch(switchHideConvNameElName, !enabledHideConvName)
-          handleHideConvNameChange.bind($(switchHideConvNameElName))()
+          ZaDarkUtils.updateHideConvName(!enabledHideConvName)
           return
         }
 
@@ -1133,9 +1085,6 @@
 
     const fontSize = ZaDarkStorage.getFontSize()
     ZaDarkUtils.setSelect(selectFontSizeElName, fontSize)
-
-    const translateTarget = ZaDarkStorage.getTranslateTarget()
-    $(selectTranslateTargetElName).setLanguagesOptions(translateTarget)
 
     const enabledHideLatestMessage = ZaDarkStorage.getEnabledHideLatestMessage()
     ZaDarkUtils.setSwitch(switchHideLatestMessageElName, enabledHideLatestMessage)
@@ -1199,7 +1148,13 @@
     })
   }
 
-  const setZaDarkPopupVisible = (popupInstance, buttonEl, popupEl, visible = true) => {
+  const loadTranslate = () => {
+    const translateTarget = ZaDarkStorage.getTranslateTarget()
+    $(selectTranslateTargetElName).setLanguagesOptions(translateTarget)
+    $(document).enableTranslateMessage(translateTarget)
+  }
+
+  const setZaDarkPopupVisible = (buttonEl, popupEl, visible = true) => {
     if (visible) {
       buttonEl.classList.add('selected')
       popupEl.setAttribute('data-visible', '')
@@ -1207,29 +1162,19 @@
       buttonEl.classList.remove('selected')
       popupEl.removeAttribute('data-visible')
     }
-
-    popupInstance.setOptions((options) => ({
-      ...options,
-      modifiers: [
-        ...options.modifiers,
-        { name: 'eventListeners', enabled: visible }
-      ]
-    }))
-
-    popupInstance.update()
   }
 
-  const handleOpenZaDarkPopup = (popupInstance, buttonEl, popupEl) => {
+  const handleOpenZaDarkPopup = (buttonEl, popupEl) => {
     return () => {
       loadPopupState()
       ZaDarkUtils.updateKnownVersionState(buttonEl)
 
-      setZaDarkPopupVisible(popupInstance, buttonEl, popupEl, true)
+      setZaDarkPopupVisible(buttonEl, popupEl, true)
       calcPopupScroll()
     }
   }
 
-  const handleCloseZaDarkPopup = (popupInstance, buttonEl, popupEl) => {
+  const handleCloseZaDarkPopup = (buttonEl, popupEl) => {
     return (event) => {
       const isOpen = popupEl.getAttribute('data-visible') !== null
       const isClickOutside = isOpen && !popupEl.contains(event.target) && !buttonEl.contains(event.target)
@@ -1238,7 +1183,7 @@
         return
       }
 
-      setZaDarkPopupVisible(popupInstance, buttonEl, popupEl, false)
+      setZaDarkPopupVisible(buttonEl, popupEl, false)
     }
   }
 
@@ -1275,36 +1220,68 @@
     const zaloAppBody = document.body
     zaloAppBody.insertAdjacentHTML('beforeend', zadarkPopupHTML)
 
-    $(radioInputThemeElName).on('change', handleThemeChange)
-    $(inputFontFamilyElName).keypress(handleInputFontFamilyKeyPress)
-    $(selectFontSizeElName).on('change', handleFontSizeChange)
-    $(selectTranslateTargetElName).on('change', handleTranslateTargetChange)
+    $(radioInputThemeElName).on('change', function () {
+      const theme = $(this).val()
+      ZaDarkUtils.updateTheme(theme)
+    })
 
-    $(switchHideLatestMessageElName).on('change', handleHideLastestMessageChange)
-    $(switchHideConvAvatarElName).on('change', handleHideConvAvatarChange)
-    $(switchHideConvNameElName).on('change', handleHideConvNameChange)
-    $(switchHideThreadChatMessageElName).on('change', handleHideThreadChatMessageChange)
+    $(inputFontFamilyElName).keypress(handleInputFontFamilyKeyPress)
+
+    $(selectFontSizeElName).on('change', function () {
+      const fontSize = $(this).val()
+      ZaDarkUtils.updateFontSize(fontSize)
+    })
+
+    $(selectTranslateTargetElName).on('change', function () {
+      const translateTarget = $(this).val()
+      ZaDarkUtils.updateTranslateTarget(translateTarget)
+
+      $(document).disableTranslateMessage()
+      if (translateTarget !== 'none') {
+        $(document).enableTranslateMessage(translateTarget)
+      }
+    })
+
+    $(switchHideLatestMessageElName).on('change', function () {
+      const isEnabled = $(this).is(':checked')
+      ZaDarkUtils.updateHideLatestMessage(isEnabled)
+    })
+
+    $(switchHideConvAvatarElName).on('change', function () {
+      const isEnabled = $(this).is(':checked')
+      ZaDarkUtils.updateHideConvAvatar(isEnabled)
+    })
+
+    $(switchHideConvNameElName).on('change', function () {
+      const isEnabled = $(this).is(':checked')
+      ZaDarkUtils.updateHideConvName(isEnabled)
+    })
+
+    $(switchHideThreadChatMessageElName).on('change', function () {
+      const isEnabled = $(this).is(':checked')
+      ZaDarkUtils.updateHideThreadChatMessage(isEnabled)
+    })
 
     $(switchBlockTypingElName).on('change', handleBlockSettingsChange('block_typing'))
     $(switchBlockSeenElName).on('change', handleBlockSettingsChange('block_seen'))
     $(switchBlockDeliveredElName).on('change', handleBlockSettingsChange('block_delivered'))
 
-    $(switchUseHotkeysElName).on('change', handleUseHotkeysChange)
+    $(switchUseHotkeysElName).on('change', function () {
+      const isEnabled = $(this).is(':checked')
+      ZaDarkUtils.updateUseHotkeys(isEnabled)
+      loadHotkeys(isEnabled)
+    })
 
     const popupEl = document.querySelector('#js-zadark-popup')
     const buttonEl = document.getElementById('div_Main_TabZaDark')
 
-    const popupInstance = Popper.createPopper(buttonEl, popupEl, {
-      placement: 'right'
-    })
-
-    buttonEl.addEventListener('click', handleOpenZaDarkPopup(popupInstance, buttonEl, popupEl))
+    buttonEl.addEventListener('click', handleOpenZaDarkPopup(buttonEl, popupEl))
 
     const closeEventNames = ['click', 'contextmenu']
     closeEventNames.forEach((eventName) => {
       window.addEventListener(
         eventName,
-        handleCloseZaDarkPopup(popupInstance, buttonEl, popupEl),
+        handleCloseZaDarkPopup(buttonEl, popupEl),
         true
       )
     })
@@ -1313,6 +1290,7 @@
     loadHotkeysState()
     loadKnownVersionState(buttonEl)
     loadPopupScrollEvent()
+    loadTranslate()
     loadTippy()
 
     ZaDarkUtils.migrateData()
@@ -1333,21 +1311,17 @@
         return
       }
 
-      setZaDarkPopupVisible(popupInstance, buttonEl, popupEl, false)
+      setZaDarkPopupVisible(buttonEl, popupEl, false)
 
       const introOptions = {
-        onExit: () => setZaDarkPopupVisible(popupInstance, buttonEl, popupEl, true),
-        onComplete: () => setZaDarkPopupVisible(popupInstance, buttonEl, popupEl, true)
+        onExit: () => setZaDarkPopupVisible(buttonEl, popupEl, true),
+        onComplete: () => setZaDarkPopupVisible(buttonEl, popupEl, true)
       }
 
       if (introId === 'hideThreadChatMessage') {
         ZaDarkUtils.showIntroHideThreadChatMessage(introOptions)
       }
     })
-
-    if (ZaDarkUtils.getTranslateTargetAttr() !== 'none') {
-      $(document).zadarkTranslateMessage(ZaDarkUtils.getTranslateTargetAttr)
-    }
   }
 
   const observer = new MutationObserver((mutationsList) => {

--- a/src/pc/assets/js/zadark.js
+++ b/src/pc/assets/js/zadark.js
@@ -1205,7 +1205,7 @@
     tippy('#js-select-translate-target', {
       theme: 'zadark',
       allowHTML: true,
-      content: 'Chọn ngôn ngữ hiển thị'
+      content: 'Bạn muốn dịch sang ngôn ngữ nào?'
     })
   }
 

--- a/src/pc/assets/js/zadark.js
+++ b/src/pc/assets/js/zadark.js
@@ -1345,7 +1345,9 @@
       }
     })
 
-    $(document).zadarkTranslateMessage(ZaDarkUtils.getTranslateTargetAttr)
+    if (ZaDarkUtils.getTranslateTargetAttr() !== 'none') {
+      $(document).zadarkTranslateMessage(ZaDarkUtils.getTranslateTargetAttr)
+    }
   }
 
   const observer = new MutationObserver((mutationsList) => {

--- a/src/pc/assets/js/zadark.js
+++ b/src/pc/assets/js/zadark.js
@@ -786,11 +786,6 @@
               <span class="zadark-beta"></span>
             </label>
 
-            <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" style="margin-right: 8px; color: var(--zadark-neutral-600);">
-              <path d="M0 0h24v24H0V0z" fill="none"></path>
-              <path d="M5 13h11.17l-4.88 4.88c-.39.39-.39 1.03 0 1.42.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41l-6.58-6.6c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L16.17 11H5c-.55 0-1 .45-1 1s.45 1 1 1z" fill="currentColor"></path>
-            </svg>
-
             <select id="js-select-translate-target" class="zadark-select"></select>
           </div>
         </div>
@@ -1205,6 +1200,12 @@
       allowHTML: true,
       content: '<p>Nhập tên phông chữ từ <strong>Google Fonts</strong><br>(Lưu ý kí tự in hoa, khoảng cách).</p><p>Bỏ trống nếu dùng phông mặc định.</p><p>Nhấn <strong>Enter</strong> để áp dụng.</p>',
       trigger: 'focus'
+    })
+
+    tippy('#js-select-translate-target', {
+      theme: 'zadark',
+      allowHTML: true,
+      content: 'Chọn ngôn ngữ hiển thị'
     })
   }
 

--- a/src/pc/package.json
+++ b/src/pc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadark-pc",
   "description": "Dark Mode tốt nhất cho Zalo",
-  "version": "12.6",
+  "version": "12.7",
   "main": "index.js",
   "repository": "https://github.com/quaric/zadark.git",
   "author": {

--- a/src/web/js/popup.js
+++ b/src/web/js/popup.js
@@ -61,7 +61,11 @@ ZaDarkBrowser.getExtensionSettings().then(({
 
 $(radioInputThemeElName).on('change', async function () {
   const theme = $(this).val()
-  await ZaDarkUtils.updateTheme(theme)
+
+  // Set theme for popup
+  ZaDarkUtils.setPageTheme(theme)
+
+  // Set theme for Zalo tabs
   ZaDarkBrowser.sendMessage2ZaloTabs(MSG_ACTIONS.CHANGE_THEME, { theme })
 })
 
@@ -84,44 +88,37 @@ $(inputFontFamilyElName).keypress(async function (event) {
 
 $(selectFontSizeElName).on('change', async function () {
   const fontSize = $(this).val()
-  await ZaDarkUtils.updateFontSize(fontSize)
   ZaDarkBrowser.sendMessage2ZaloTabs(MSG_ACTIONS.CHANGE_FONT_SIZE, { fontSize })
 })
 
 $(selectTranslateTargetElName).on('change', async function () {
   const translateTarget = $(this).val()
-  await ZaDarkUtils.updateTranslateTarget(translateTarget)
   ZaDarkBrowser.sendMessage2ZaloTabs(MSG_ACTIONS.CHANGE_TRANSLATE_TARGET, { translateTarget })
 })
 
 $(switchHideLatestMessageElName).on('change', async function () {
-  const enabledHideLatestMessage = $(this).is(':checked')
-  await ZaDarkUtils.updateHideLatestMessage(enabledHideLatestMessage)
-  ZaDarkBrowser.sendMessage2ZaloTabs(MSG_ACTIONS.CHANGE_HIDE_LATEST_MESSAGE, { enabledHideLatestMessage })
+  const isEnabled = $(this).is(':checked')
+  ZaDarkBrowser.sendMessage2ZaloTabs(MSG_ACTIONS.CHANGE_HIDE_LATEST_MESSAGE, { isEnabled })
 })
 
 $(switchHideConvAvatarElName).on('change', async function () {
-  const enabledHideConvAvatar = $(this).is(':checked')
-  await ZaDarkUtils.updateHideConvAvatar(enabledHideConvAvatar)
-  ZaDarkBrowser.sendMessage2ZaloTabs(MSG_ACTIONS.CHANGE_HIDE_CONV_AVATAR, { enabledHideConvAvatar })
+  const isEnabled = $(this).is(':checked')
+  ZaDarkBrowser.sendMessage2ZaloTabs(MSG_ACTIONS.CHANGE_HIDE_CONV_AVATAR, { isEnabled })
 })
 
 $(switchHideConvNameElName).on('change', async function () {
-  const enabledHideConvName = $(this).is(':checked')
-  await ZaDarkUtils.updateHideConvName(enabledHideConvName)
-  ZaDarkBrowser.sendMessage2ZaloTabs(MSG_ACTIONS.CHANGE_HIDE_CONV_NAME, { enabledHideConvName })
+  const isEnabled = $(this).is(':checked')
+  ZaDarkBrowser.sendMessage2ZaloTabs(MSG_ACTIONS.CHANGE_HIDE_CONV_NAME, { isEnabled })
 })
 
 $(switchHideThreadChatMessageElName).on('change', async function () {
-  const enabledHideThreadChatMessage = $(this).is(':checked')
-  await ZaDarkUtils.updateHideThreadChatMessage(enabledHideThreadChatMessage)
-  ZaDarkBrowser.sendMessage2ZaloTabs(MSG_ACTIONS.CHANGE_HIDE_THREAD_CHAT_MESSAGE, { enabledHideThreadChatMessage })
+  const isEnabled = $(this).is(':checked')
+  ZaDarkBrowser.sendMessage2ZaloTabs(MSG_ACTIONS.CHANGE_HIDE_THREAD_CHAT_MESSAGE, { isEnabled })
 })
 
 $(switchUseHotkeysElName).on('change', async function () {
-  const useHotkeys = $(this).is(':checked')
-  await ZaDarkUtils.updateUseHotkeys(useHotkeys)
-  ZaDarkBrowser.sendMessage2ZaloTabs(MSG_ACTIONS.CHANGE_USE_HOTKEYS, { useHotkeys })
+  const isEnabled = $(this).is(':checked')
+  ZaDarkBrowser.sendMessage2ZaloTabs(MSG_ACTIONS.CHANGE_USE_HOTKEYS, { isEnabled })
 })
 
 const handleBlockingRuleChange = (elName, ruleId) => {

--- a/src/web/js/utils.js
+++ b/src/web/js/utils.js
@@ -316,7 +316,7 @@
       tippy('#js-select-translate-target', {
         theme: 'zadark',
         allowHTML: true,
-        content: 'Chọn ngôn ngữ hiển thị'
+        content: 'Bạn muốn dịch sang ngôn ngữ nào?'
       })
     },
 

--- a/src/web/js/utils.js
+++ b/src/web/js/utils.js
@@ -312,6 +312,12 @@
         content: '<p>Nhập tên phông chữ từ <strong>Google Fonts</strong><br>(Lưu ý kí tự in hoa, khoảng cách).</p><p>Bỏ trống nếu dùng phông mặc định.</p><p>Nhấn <strong>Enter</strong> để áp dụng.</p>',
         trigger: 'focus'
       })
+
+      tippy('#js-select-translate-target', {
+        theme: 'zadark',
+        allowHTML: true,
+        content: 'Chọn ngôn ngữ hiển thị'
+      })
     },
 
     updateTheme: async function (theme) {

--- a/src/web/js/utils.js
+++ b/src/web/js/utils.js
@@ -95,14 +95,6 @@
       document.documentElement.setAttribute('data-zadark-font-size', fontSize)
     },
 
-    setTranslateTargetAttr: (translateTarget) => {
-      document.documentElement.setAttribute('data-zadark-trans-target', translateTarget)
-    },
-
-    getTranslateTargetAttr: () => {
-      return document.documentElement.getAttribute('data-zadark-trans-target') || 'vi'
-    },
-
     setHideLatestMessageAttr: function (isEnabled) {
       this.toggleBodyClassName('zadark-prv--latest-message', isEnabled)
     },
@@ -268,7 +260,6 @@
       const {
         theme,
         fontSize,
-        translateTarget,
 
         enabledHideLatestMessage,
         enabledHideConvAvatar,
@@ -280,7 +271,6 @@
 
       this.setPageTheme(theme)
       this.setFontSizeAttr(fontSize)
-      this.setTranslateTargetAttr(translateTarget)
 
       this.setHideLatestMessageAttr(enabledHideLatestMessage)
       this.setHideConvAvatarAttr(enabledHideConvAvatar)
@@ -364,8 +354,7 @@
     },
 
     updateTranslateTarget: async function (translateTarget) {
-      await ZaDarkBrowser.saveExtensionSettings({ translateTarget })
-      this.setTranslateTargetAttr(translateTarget)
+      return ZaDarkBrowser.saveExtensionSettings({ translateTarget })
     },
 
     updateHideLatestMessage: async function (enabledHideLatestMessage) {

--- a/src/web/js/zadark.js
+++ b/src/web/js/zadark.js
@@ -787,7 +787,9 @@
       }
     })
 
-    $(document).zadarkTranslateMessage(ZaDarkUtils.getTranslateTargetAttr)
+    if (ZaDarkUtils.getTranslateTargetAttr() !== 'none') {
+      $(document).zadarkTranslateMessage(ZaDarkUtils.getTranslateTargetAttr)
+    }
   }
 
   const observer = new MutationObserver((mutationsList) => {

--- a/src/web/js/zadark.js
+++ b/src/web/js/zadark.js
@@ -198,11 +198,6 @@
               <span class="zadark-beta"></span>
             </label>
 
-            <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" style="margin-right: 8px; color: var(--zadark-neutral-600);">
-              <path d="M0 0h24v24H0V0z" fill="none"></path>
-              <path d="M5 13h11.17l-4.88 4.88c-.39.39-.39 1.03 0 1.42.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41l-6.58-6.6c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L16.17 11H5c-.55 0-1 .45-1 1s.45 1 1 1z" fill="currentColor"></path>
-            </svg>
-
             <select id="js-select-translate-target" class="zadark-select"></select>
           </div>
         </div>

--- a/src/web/js/zadark.js
+++ b/src/web/js/zadark.js
@@ -42,11 +42,6 @@
     $(elName).prop('checked', enabled)
   }
 
-  function handleSelectThemeChange () {
-    const theme = $(this).val()
-    ZaDarkUtils.updateTheme(theme)
-  }
-
   const handleNextTheme = async () => {
     const {
       theme
@@ -56,9 +51,7 @@
 
     const nextIndex = themes.indexOf(theme) + 1
     const nextTheme = themes[nextIndex] || themes[0]
-
-    setRadioInputTheme(nextTheme)
-    ZaDarkUtils.updateTheme(nextTheme)
+    updateTheme(nextTheme)
   }
 
   async function handleInputFontFamilyKeyPress (event) {
@@ -76,11 +69,6 @@
     }
   }
 
-  function handleSelectFontSizeChange () {
-    const fontSize = $(this).val()
-    ZaDarkUtils.updateFontSize(fontSize)
-  }
-
   const handleNextFontSize = async (count) => {
     const {
       fontSize
@@ -93,34 +81,7 @@
       : Math.max(fontSizes.indexOf(fontSize) - 1, 0)
 
     const nextFontSize = fontSizes[nextIndex]
-
-    setSelect(selectFontSizeElName, nextFontSize)
-    handleSelectFontSizeChange.bind($(selectFontSizeElName))()
-  }
-
-  function handleSelectTranslateTargetChange () {
-    const translateTarget = $(this).val()
-    ZaDarkUtils.updateTranslateTarget(translateTarget)
-  }
-
-  function handleHideLatestMessageChange () {
-    const enabledHideLatestMessage = $(this).is(':checked')
-    ZaDarkUtils.updateHideLatestMessage(enabledHideLatestMessage)
-  }
-
-  function handleHideConvAvatarChange () {
-    const enabledHideConvAvatar = $(this).is(':checked')
-    ZaDarkUtils.updateHideConvAvatar(enabledHideConvAvatar)
-  }
-
-  function handleHideConvNameChange () {
-    const enabledHideConvName = $(this).is(':checked')
-    ZaDarkUtils.updateHideConvName(enabledHideConvName)
-  }
-
-  function handleHideThreadChatMessageChange () {
-    const enabledHideThreadChatMessage = $(this).is(':checked')
-    ZaDarkUtils.updateHideThreadChatMessage(enabledHideThreadChatMessage)
+    updateFontSize(nextFontSize)
   }
 
   const handleBlockingRuleChange = (ruleId) => {
@@ -137,9 +98,8 @@
   }
 
   function handleUseHotkeysChange () {
-    const useHotkeys = $(this).is(':checked')
-    ZaDarkUtils.updateUseHotkeys(useHotkeys)
-    loadHotkeys(useHotkeys)
+    const isEnabled = $(this).is(':checked')
+    useHotkeys(isEnabled)
   }
 
   const zadarkButtonHTML = `
@@ -237,6 +197,11 @@
               <i class="zadark-icon zadark-icon--question" data-tippy-content='Bạn di chuyển chuột vào đoạn tin nhắn<br/>và chọn biểu tượng <i class="zadark-icon zadark-icon--translate" style="position: relative; top: 3px; font-size: 18px;"></i> để dịch tin nhắn.'></i>
               <span class="zadark-beta"></span>
             </label>
+
+            <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" style="margin-right: 8px; color: var(--zadark-neutral-600);">
+              <path d="M0 0h24v24H0V0z" fill="none"></path>
+              <path d="M5 13h11.17l-4.88 4.88c-.39.39-.39 1.03 0 1.42.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41l-6.58-6.6c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L16.17 11H5c-.55 0-1 .45-1 1s.45 1 1 1z" fill="currentColor"></path>
+            </svg>
 
             <select id="js-select-translate-target" class="zadark-select"></select>
           </div>
@@ -474,32 +439,28 @@
         // Hide latest message
         case 'command+1':
         case 'ctrl+1': {
-          setSwitch(switchHideLatestMessageElName, !enabledHideLatestMessage)
-          handleHideLatestMessageChange.bind($(switchHideLatestMessageElName))()
+          hideLatestMessage(!enabledHideLatestMessage)
           return
         }
 
         // Hide thread chat message
         case 'command+2':
         case 'ctrl+2': {
-          setSwitch(switchHideThreadChatMessageElName, !enabledHideThreadChatMessage)
-          handleHideThreadChatMessageChange.bind($(switchHideThreadChatMessageElName))()
+          hideThreadChatMessage(!enabledHideThreadChatMessage)
           return
         }
 
         // Hide conversation avatar
         case 'command+3':
         case 'ctrl+3': {
-          setSwitch(switchHideConvAvatarElName, !enabledHideConvAvatar)
-          handleHideConvAvatarChange.bind($(switchHideConvAvatarElName))()
+          hideConvAvatar(!enabledHideConvAvatar)
           return
         }
 
         // Hide conversation name
         case 'command+7':
         case 'ctrl+7': {
-          setSwitch(switchHideConvNameElName, !enabledHideConvName)
-          handleHideConvNameChange.bind($(switchHideConvNameElName))()
+          hideConvName(!enabledHideConvName)
           return
         }
 
@@ -555,18 +516,15 @@
       theme,
       fontFamily,
       fontSize,
-      translateTarget,
       enabledHideLatestMessage,
       enabledHideConvAvatar,
       enabledHideConvName,
-      enabledHideThreadChatMessage,
-      useHotkeys
+      enabledHideThreadChatMessage
     } = await ZaDarkBrowser.getExtensionSettings()
 
     setRadioInputTheme(theme)
     setSelect(inputFontFamilyElName, fontFamily)
     setSelect(selectFontSizeElName, fontSize)
-    $(selectTranslateTargetElName).setLanguagesOptions(translateTarget)
 
     setSwitch(switchHideLatestMessageElName, enabledHideLatestMessage)
     setSwitch(switchHideConvAvatarElName, enabledHideConvAvatar)
@@ -574,11 +532,11 @@
     setSwitch(switchHideThreadChatMessageElName, enabledHideThreadChatMessage)
 
     loadBlocking(ZaDarkUtils.isSupportDeclarativeNetRequest())
-    setSwitch(switchUseHotkeysElName, useHotkeys)
   }
 
   const loadHotkeysState = async () => {
     const { useHotkeys } = await ZaDarkBrowser.getExtensionSettings()
+    setSwitch(switchUseHotkeysElName, useHotkeys)
     loadHotkeys(useHotkeys)
   }
 
@@ -621,7 +579,13 @@
     })
   }
 
-  const setZaDarkPopupVisible = (popupInstance, buttonEl, popupEl, visible = true) => {
+  const loadTranslate = async () => {
+    const { translateTarget } = await ZaDarkBrowser.getExtensionSettings()
+    $(selectTranslateTargetElName).setLanguagesOptions(translateTarget)
+    $(document).enableTranslateMessage(translateTarget)
+  }
+
+  const setZaDarkPopupVisible = (buttonEl, popupEl, visible = true) => {
     if (visible) {
       buttonEl.classList.add('selected')
       popupEl.setAttribute('data-visible', '')
@@ -629,29 +593,19 @@
       buttonEl.classList.remove('selected')
       popupEl.removeAttribute('data-visible')
     }
-
-    popupInstance.setOptions((options) => ({
-      ...options,
-      modifiers: [
-        ...options.modifiers,
-        { name: 'eventListeners', enabled: visible }
-      ]
-    }))
-
-    popupInstance.update()
   }
 
-  const handleOpenZaDarkPopup = (popupInstance, buttonEl, popupEl) => {
+  const handleOpenZaDarkPopup = (buttonEl, popupEl) => {
     return () => {
       loadPopupState()
       updateKnownVersionState(buttonEl)
 
-      setZaDarkPopupVisible(popupInstance, buttonEl, popupEl, true)
+      setZaDarkPopupVisible(buttonEl, popupEl, true)
       calcPopupScroll()
     }
   }
 
-  const handleCloseZaDarkPopup = (popupInstance, buttonEl, popupEl) => {
+  const handleCloseZaDarkPopup = (buttonEl, popupEl) => {
     return (event) => {
       const isOpen = popupEl.getAttribute('data-visible') !== null
       const isClickOutside = isOpen && !popupEl.contains(event.target) && !buttonEl.contains(event.target)
@@ -660,7 +614,7 @@
         return
       }
 
-      setZaDarkPopupVisible(popupInstance, buttonEl, popupEl, false)
+      setZaDarkPopupVisible(buttonEl, popupEl, false)
     }
   }
 
@@ -719,15 +673,42 @@
     // const settingsWrapper = getSettingsWrapper()
     // settingsWrapper.insertAdjacentHTML('beforeend', zadarkPopupHTML)
 
-    $(radioInputThemeElName).on('change', handleSelectThemeChange)
-    $(inputFontFamilyElName).keypress(handleInputFontFamilyKeyPress)
-    $(selectFontSizeElName).on('change', handleSelectFontSizeChange)
-    $(selectTranslateTargetElName).on('change', handleSelectTranslateTargetChange)
+    $(radioInputThemeElName).on('change', function () {
+      const theme = $(this).val()
+      updateTheme(theme)
+    })
 
-    $(switchHideLatestMessageElName).on('change', handleHideLatestMessageChange)
-    $(switchHideConvAvatarElName).on('change', handleHideConvAvatarChange)
-    $(switchHideConvNameElName).on('change', handleHideConvNameChange)
-    $(switchHideThreadChatMessageElName).on('change', handleHideThreadChatMessageChange)
+    $(inputFontFamilyElName).keypress(handleInputFontFamilyKeyPress)
+
+    $(selectFontSizeElName).on('change', function () {
+      const fontSize = $(this).val()
+      updateFontSize(fontSize)
+    })
+
+    $(selectTranslateTargetElName).on('change', function () {
+      const translateTarget = $(this).val()
+      updateTranslateTarget(translateTarget)
+    })
+
+    $(switchHideLatestMessageElName).on('change', function () {
+      const isEnabled = $(this).is(':checked')
+      hideLatestMessage(isEnabled)
+    })
+
+    $(switchHideConvAvatarElName).on('change', function () {
+      const isEnabled = $(this).is(':checked')
+      hideConvAvatar(isEnabled)
+    })
+
+    $(switchHideConvNameElName).on('change', function () {
+      const isEnabled = $(this).is(':checked')
+      hideConvName(isEnabled)
+    })
+
+    $(switchHideThreadChatMessageElName).on('change', function () {
+      const isEnabled = $(this).is(':checked')
+      hideThreadChatMessage(isEnabled)
+    })
 
     $(switchBlockTypingElName).on('change', handleBlockingRuleChange('rules_block_typing'))
     $(switchBlockSeenElName).on('change', handleBlockingRuleChange('rules_block_seen'))
@@ -738,17 +719,13 @@
     const popupEl = document.querySelector('#js-zadark-popup')
     const buttonEl = document.getElementById('div_Main_TabZaDark')
 
-    const popupInstance = Popper.createPopper(buttonEl, popupEl, {
-      placement: 'right'
-    })
-
-    buttonEl.addEventListener('click', handleOpenZaDarkPopup(popupInstance, buttonEl, popupEl))
+    buttonEl.addEventListener('click', handleOpenZaDarkPopup(buttonEl, popupEl))
 
     const closeEventNames = ['click', 'contextmenu']
     closeEventNames.forEach((eventName) => {
       window.addEventListener(
         eventName,
-        handleCloseZaDarkPopup(popupInstance, buttonEl, popupEl),
+        handleCloseZaDarkPopup(buttonEl, popupEl),
         true
       )
     })
@@ -757,6 +734,8 @@
     loadHotkeysState()
     loadKnownVersionState(buttonEl)
     loadPopupScrollEvent()
+    loadTranslate()
+
     ZaDarkUtils.initTippy()
 
     $('[data-zdk-intro]').on('click', function (e) {
@@ -775,21 +754,17 @@
         return
       }
 
-      setZaDarkPopupVisible(popupInstance, buttonEl, popupEl, false)
+      setZaDarkPopupVisible(buttonEl, popupEl, false)
 
       const introOptions = {
-        onExit: () => setZaDarkPopupVisible(popupInstance, buttonEl, popupEl, true),
-        onComplete: () => setZaDarkPopupVisible(popupInstance, buttonEl, popupEl, true)
+        onExit: () => setZaDarkPopupVisible(buttonEl, popupEl, true),
+        onComplete: () => setZaDarkPopupVisible(buttonEl, popupEl, true)
       }
 
       if (introId === 'hideThreadChatMessage') {
         ZaDarkUtils.showIntroHideThreadChatMessage(introOptions)
       }
     })
-
-    if (ZaDarkUtils.getTranslateTargetAttr() !== 'none') {
-      $(document).zadarkTranslateMessage(ZaDarkUtils.getTranslateTargetAttr)
-    }
   }
 
   const observer = new MutationObserver((mutationsList) => {
@@ -805,70 +780,100 @@
 
   observer.observe(document.querySelector('#app'), { subtree: false, childList: true })
 
+  const updateTheme = (theme = 'dark') => {
+    setRadioInputTheme(theme)
+    ZaDarkUtils.updateTheme(theme)
+  }
+
+  const updateFontSize = (fontSize = 'medium') => {
+    setSelect(selectFontSizeElName, fontSize)
+    ZaDarkUtils.updateFontSize(fontSize)
+  }
+
+  const updateTranslateTarget = (translateTarget = 'none') => {
+    setSelect(selectTranslateTargetElName, translateTarget)
+    ZaDarkUtils.updateTranslateTarget(translateTarget)
+
+    $(document).disableTranslateMessage()
+    if (translateTarget !== 'none') {
+      $(document).enableTranslateMessage(translateTarget)
+    }
+  }
+
+  const hideLatestMessage = (isEnabled) => {
+    setSwitch(switchHideLatestMessageElName, isEnabled)
+    ZaDarkUtils.updateHideLatestMessage(isEnabled)
+  }
+
+  const hideConvAvatar = (isEnabled) => {
+    setSwitch(switchHideConvAvatarElName, isEnabled)
+    ZaDarkUtils.updateHideConvAvatar(isEnabled)
+  }
+
+  const hideConvName = (isEnabled) => {
+    setSwitch(switchHideConvNameElName, isEnabled)
+    ZaDarkUtils.updateHideConvName(isEnabled)
+  }
+
+  const hideThreadChatMessage = (isEnabled) => {
+    setSwitch(switchHideThreadChatMessageElName, isEnabled)
+    ZaDarkUtils.updateHideThreadChatMessage(isEnabled)
+  }
+
+  const useHotkeys = (isEnabled) => {
+    setSwitch(switchUseHotkeysElName, isEnabled)
+    loadHotkeys(isEnabled)
+    ZaDarkUtils.updateUseHotkeys(isEnabled)
+  }
+
   const MSG_ACTIONS = ZaDarkUtils.MSG_ACTIONS
 
   ZaDarkBrowser.addMessageListener((message, sender, sendResponse) => {
     if (message.action === MSG_ACTIONS.CHANGE_THEME) {
-      const theme = message.payload.theme
-      setRadioInputTheme(theme)
-      ZaDarkUtils.setPageTheme(theme)
-
+      const { theme } = message.payload
+      updateTheme(theme)
       sendResponse({ received: true })
     }
 
     if (message.action === MSG_ACTIONS.CHANGE_FONT_SIZE) {
-      const fontSize = message.payload.fontSize
-      setSelect(selectFontSizeElName, fontSize)
-      ZaDarkUtils.setFontSizeAttr(fontSize)
-
+      const { fontSize } = message.payload
+      updateFontSize(fontSize)
       sendResponse({ received: true })
     }
 
     if (message.action === MSG_ACTIONS.CHANGE_TRANSLATE_TARGET) {
-      const translateTarget = message.payload.translateTarget
-      setSelect(selectTranslateTargetElName, translateTarget)
-      ZaDarkUtils.setTranslateTargetAttr(translateTarget)
-
+      const { translateTarget } = message.payload
+      updateTranslateTarget(translateTarget)
       sendResponse({ received: true })
     }
 
     if (message.action === MSG_ACTIONS.CHANGE_HIDE_LATEST_MESSAGE) {
-      const isEnabled = message.payload.enabledHideLatestMessage
-      setSwitch(switchHideLatestMessageElName, isEnabled)
-      ZaDarkUtils.setHideLatestMessageAttr(isEnabled)
-
+      const { isEnabled } = message.payload
+      hideLatestMessage(isEnabled)
       sendResponse({ received: true })
     }
 
     if (message.action === MSG_ACTIONS.CHANGE_HIDE_CONV_AVATAR) {
-      const isEnabled = message.payload.enabledHideConvAvatar
-      setSwitch(switchHideConvAvatarElName, isEnabled)
-      ZaDarkUtils.setHideConvAvatarAttr(isEnabled)
-
+      const { isEnabled } = message.payload
+      hideConvAvatar(isEnabled)
       sendResponse({ received: true })
     }
 
     if (message.action === MSG_ACTIONS.CHANGE_HIDE_CONV_NAME) {
-      const isEnabled = message.payload.enabledHideConvName
-      setSwitch(switchHideConvNameElName, isEnabled)
-      ZaDarkUtils.setHideConvNameAttr(isEnabled)
-
+      const { isEnabled } = message.payload
+      hideConvName(isEnabled)
       sendResponse({ received: true })
     }
 
     if (message.action === MSG_ACTIONS.CHANGE_HIDE_THREAD_CHAT_MESSAGE) {
-      const isEnabled = message.payload.enabledHideThreadChatMessage
-      setSwitch(switchHideThreadChatMessageElName, isEnabled)
-      ZaDarkUtils.setHideThreadChatMessageAttr(isEnabled)
-
+      const { isEnabled } = message.payload
+      hideThreadChatMessage(isEnabled)
       sendResponse({ received: true })
     }
 
     if (message.action === MSG_ACTIONS.CHANGE_USE_HOTKEYS) {
-      const isEnabled = message.payload.useHotkeys
-      loadHotkeys(isEnabled)
-      ZaDarkUtils.setUseHotkeysAttr(isEnabled)
-
+      const { isEnabled } = message.payload
+      useHotkeys(isEnabled)
       sendResponse({ received: true })
     }
 

--- a/src/web/popup.html
+++ b/src/web/popup.html
@@ -92,6 +92,11 @@
             <span class="zadark-beta"></span>
           </label>
 
+          <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" style="margin-right: 8px; color: var(--zadark-neutral-600);">
+            <path d="M0 0h24v24H0V0z" fill="none"></path>
+            <path d="M5 13h11.17l-4.88 4.88c-.39.39-.39 1.03 0 1.42.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41l-6.58-6.6c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L16.17 11H5c-.55 0-1 .45-1 1s.45 1 1 1z" fill="currentColor"></path>
+          </svg>
+
           <select id="js-select-translate-target" class="zadark-select"></select>
         </div>
       </div>

--- a/src/web/popup.html
+++ b/src/web/popup.html
@@ -92,11 +92,6 @@
             <span class="zadark-beta"></span>
           </label>
 
-          <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" style="margin-right: 8px; color: var(--zadark-neutral-600);">
-            <path d="M0 0h24v24H0V0z" fill="none"></path>
-            <path d="M5 13h11.17l-4.88 4.88c-.39.39-.39 1.03 0 1.42.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41l-6.58-6.6c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41L16.17 11H5c-.55 0-1 .45-1 1s.45 1 1 1z" fill="currentColor"></path>
-          </svg>
-
           <select id="js-select-translate-target" class="zadark-select"></select>
         </div>
       </div>

--- a/src/web/vendor/chrome/manifest.json
+++ b/src/web/vendor/chrome/manifest.json
@@ -27,8 +27,8 @@
         "libs/libs.min.js",
         "js/fonts.min.js",
         "js/browser.min.js",
-        "js/utils.min.js",
         "js/zadark-translate.min.js",
+        "js/utils.min.js",
         "js/zadark.min.js"
       ]
     }

--- a/src/web/vendor/chrome/manifest.json
+++ b/src/web/vendor/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ZaDark – Zalo Dark Mode",
-  "version": "9.23",
+  "version": "9.24",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "Quaric",

--- a/src/web/vendor/edge/manifest.json
+++ b/src/web/vendor/edge/manifest.json
@@ -27,8 +27,8 @@
         "libs/libs.min.js",
         "js/fonts.min.js",
         "js/browser.min.js",
-        "js/utils.min.js",
         "js/zadark-translate.min.js",
+        "js/utils.min.js",
         "js/zadark.min.js"
       ]
     }

--- a/src/web/vendor/edge/manifest.json
+++ b/src/web/vendor/edge/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ZaDark – Zalo Dark Mode",
-  "version": "9.23",
+  "version": "9.24",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "Quaric",

--- a/src/web/vendor/firefox/manifest.json
+++ b/src/web/vendor/firefox/manifest.json
@@ -27,8 +27,8 @@
         "libs/libs.min.js",
         "js/fonts.min.js",
         "js/browser.min.js",
-        "js/utils.min.js",
         "js/zadark-translate.min.js",
+        "js/utils.min.js",
         "js/zadark.min.js"
       ]
     }

--- a/src/web/vendor/firefox/manifest.json
+++ b/src/web/vendor/firefox/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "ZaDark – Zalo Dark Mode",
-  "version": "9.23",
+  "version": "9.24",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "Quaric",

--- a/src/web/vendor/opera/manifest.json
+++ b/src/web/vendor/opera/manifest.json
@@ -27,8 +27,8 @@
         "libs/libs.min.js",
         "js/fonts.min.js",
         "js/browser.min.js",
-        "js/utils.min.js",
         "js/zadark-translate.min.js",
+        "js/utils.min.js",
         "js/zadark.min.js"
       ]
     }

--- a/src/web/vendor/opera/manifest.json
+++ b/src/web/vendor/opera/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ZaDark – Zalo Dark Mode",
-  "version": "9.23",
+  "version": "9.24",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "Quaric",

--- a/src/web/vendor/safari/ZaDark.xcodeproj/project.pbxproj
+++ b/src/web/vendor/safari/ZaDark.xcodeproj/project.pbxproj
@@ -533,7 +533,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
-				MARKETING_VERSION = 9.23;
+				MARKETING_VERSION = 9.24;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -572,7 +572,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
-				MARKETING_VERSION = 9.23;
+				MARKETING_VERSION = 9.24;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,

--- a/src/web/vendor/safari/manifest.json
+++ b/src/web/vendor/safari/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "ZaDark for Safari",
-  "version": "9.23",
+  "version": "9.24",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "Quaric",

--- a/src/web/vendor/safari/manifest.json
+++ b/src/web/vendor/safari/manifest.json
@@ -28,8 +28,8 @@
         "libs/libs.min.js",
         "js/fonts.min.js",
         "js/browser.min.js",
-        "js/utils.min.js",
         "js/zadark-translate.min.js",
+        "js/utils.min.js",
         "js/zadark.min.js"
       ]
     }


### PR DESCRIPTION
## ZaDark 24.2.2
> PC 12.7 và Web 9.24

- Sửa lỗi Dark Mode: Sticker mùa lễ hội
- Sửa lỗi Dark Mode: Double Click vào tin nhắn hình ảnh
- Cho phép tắt dịch tin nhắn
- Hỗ trợ dịch tin nhắn có hình ảnh
- Thêm giải thích khi chọn ngôn ngữ
- Tối ưu mã nguồn