### PR TITLE
Feature/24.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## ZaDark 24.4.2
+
+> PC 12.10.1
+
+- Hiển thị tên kiến trúc (x64, arm64) khi cài đặt ZaDark
+- **[macOS]** Homebrew: Tự động lựa chọn phiên bản ZaDark (Apple Chip, Intel Chip) phù hợp với kiến trúc máy Mac
+
 ## ZaDark 24.4.1
 
 > PC 12.10 và Web 9.27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 > PC 12.10.1
 
 - Hiển thị tên kiến trúc (x64, arm64) khi cài đặt ZaDark
-- **[macOS]** Homebrew: Tự động lựa chọn phiên bản ZaDark (Apple Chip, Intel Chip) phù hợp với kiến trúc máy Mac
+- **[macOS]** Homebrew: Tự động lựa chọn phiên bản ZaDark (Apple Chip, Intel Chip) phù hợp với kiến trúc máy Mac ([#119](https://github.com/quaric/zadark/issues/119))
 
 ## ZaDark 24.4.1
 

--- a/dist-utils.js
+++ b/dist-utils.js
@@ -68,8 +68,8 @@ const getFileNameZip = (plat) => {
   return FILE_NAME_ZIP[plat]
 }
 
-const getFileNameMacOSTar = () => {
-  return `zadark-macos-${pcPackageJSON.version}.tar`
+const getFileNameMacOSTar = (arch = 'x64') => {
+  return `zadark-macos-${pcPackageJSON.version}-${arch}.tar`
 }
 
 const getFileDir = (platform) => {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -314,15 +314,25 @@ const zipMacOSARM64 = () => {
 const tarGzipMacOSX64 = () => {
   return src(distUtils.getFilePath('MACOS_X64', true))
     .pipe(rename('zadark'))
-    .pipe(tar(distUtils.getFileNameMacOSTar()))
+    .pipe(tar(distUtils.getFileNameMacOSTar('x64')))
     .pipe(gzip())
     .pipe(dest(distUtils.getFileDir('MACOS_X64')))
 }
 
+const tarGzipMacOSARM64 = () => {
+  return src(distUtils.getFilePath('MACOS_ARM64', true))
+    .pipe(rename('zadark'))
+    .pipe(tar(distUtils.getFileNameMacOSTar('arm64')))
+    .pipe(gzip())
+    .pipe(dest(distUtils.getFileDir('MACOS_ARM64')))
+}
+
 const hashsumMacOS = () => {
-  const inp = path.join(distUtils.getFileDir('MACOS_X64'), distUtils.getFileNameMacOSTar() + '.gz')
-  const out = distUtils.getFileDir('MACOS_X64')
-  return src(inp).pipe(hashsum({ hash: 'sha256', dest: out }))
+  const inp = [
+    path.join(distUtils.getFileDir('MACOS_X64'), distUtils.getFileNameMacOSTar('x64') + '.gz'),
+    path.join(distUtils.getFileDir('MACOS_ARM64'), distUtils.getFileNameMacOSTar('arm64') + '.gz')
+  ]
+  return src(inp).pipe(hashsum({ hash: 'sha256', dest: distUtils.getFileDir('MACOS_X64') }))
 }
 
 const zipWindows = () => {
@@ -370,6 +380,7 @@ const pcDist = series(
   zipMacOSX64,
   zipMacOSARM64,
   tarGzipMacOSX64,
+  tarGzipMacOSARM64,
   hashsumMacOS,
   zipWindows,
   parallel(

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadark",
   "description": "Dark Mode tốt nhất cho Zalo",
-  "version": "24.4.1",
+  "version": "24.4.2",
   "repository": "https://github.com/quaric/zadark.git",
   "author": {
     "name": "Quaric",

--- a/src/pc/index.js
+++ b/src/pc/index.js
@@ -60,14 +60,7 @@ const handlePromptCustomZaloPath = () => {
 
 const renderHeader = () => {
   print('')
-
-  if (IS_MAC) {
-    const arch = process.arch === 'arm64' ? 'Apple Chip' : 'Intel Chip'
-    print(chalk.blueBright.bold(`ZaDark for macOS ${ZADARK_VERSION} (${arch})`))
-  } else {
-    print(chalk.blueBright.bold(`ZaDark for Windows ${ZADARK_VERSION}`))
-  }
-
+  print(chalk.blueBright.bold(`ZaDark for ${IS_MAC ? 'macOS' : 'Windows'} ${ZADARK_VERSION} (${process.arch})`))
   print(chalk.blueBright(chalk.underline('https://zadark.com')))
   print('')
 }
@@ -157,7 +150,7 @@ const handleOpenDocs = () => {
       }
 
       if (['-v', '--version'].includes(action)) {
-        print(`ZaDark ${ZADARK_VERSION}`)
+        print(`ZaDark ${ZADARK_VERSION} (${process.arch})`)
       }
     } catch (error) {
       print(chalk.magentaBright.bold('[XAY RA LOI]'))

--- a/src/pc/index.js
+++ b/src/pc/index.js
@@ -60,7 +60,14 @@ const handlePromptCustomZaloPath = () => {
 
 const renderHeader = () => {
   print('')
-  print(chalk.blueBright.bold(`ZaDark for ${IS_MAC ? 'macOS' : 'Windows'} ${ZADARK_VERSION}`))
+
+  if (IS_MAC) {
+    const arch = process.arch === 'arm64' ? 'Apple Chip' : 'Intel Chip'
+    print(chalk.blueBright.bold(`ZaDark for macOS ${ZADARK_VERSION} (${arch})`))
+  } else {
+    print(chalk.blueBright.bold(`ZaDark for Windows ${ZADARK_VERSION}`))
+  }
+
   print(chalk.blueBright(chalk.underline('https://zadark.com')))
   print('')
 }

--- a/src/pc/package.json
+++ b/src/pc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadark-pc",
   "description": "Dark Mode tốt nhất cho Zalo",
-  "version": "12.10",
+  "version": "12.10.1",
   "main": "index.js",
   "repository": "https://github.com/quaric/zadark.git",
   "author": {


### PR DESCRIPTION
## ZaDark 24.4.2

> PC 12.10.1

- Hiển thị tên kiến trúc (x64, arm64) khi cài đặt ZaDark
- **[macOS]** Homebrew: Tự động lựa chọn phiên bản ZaDark (Apple Chip, Intel Chip) phù hợp với kiến trúc máy Mac