### PR TITLE
docs(CHANGELOG.md): update version to ZaDark 24.8.1 and Web 9.33.1, a…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## ZaDark 24.8.1
+
+> Web 9.33.1
+
+- Sửa lỗi Extension Popup
+
 ## ZaDark 24.7.1
 
 > PC 12.16 và Web 9.33

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadark",
   "description": "Dark Mode tốt nhất cho Zalo",
-  "version": "24.7.1",
+  "version": "24.8.1",
   "repository": "https://github.com/quaric/zadark.git",
   "author": {
     "name": "Quaric",

--- a/src/web/js/popup.js
+++ b/src/web/js/popup.js
@@ -180,4 +180,4 @@ const calcPopupScroll = () => {
 
 calcPopupScroll()
 
-$(window).on('scroll', ZaDarkUtils.debounce(calcPopupScroll, 150))
+$(window).on('scroll', ZaDarkShared.debounce(calcPopupScroll, 150))

--- a/src/web/popup.html
+++ b/src/web/popup.html
@@ -202,6 +202,7 @@
   </button>
 
   <script src="libs/libs.min.js"></script>
+  <script src="js/zadark-shared.min.js"></script>
   <script src="js/fonts.min.js"></script>
   <script src="js/browser.min.js"></script>
   <script src="js/utils.min.js"></script>

--- a/src/web/vendor/chrome/manifest.json
+++ b/src/web/vendor/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ZaDark – Zalo Dark Mode",
-  "version": "9.33",
+  "version": "9.33.1",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "Quaric",

--- a/src/web/vendor/edge/manifest.json
+++ b/src/web/vendor/edge/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ZaDark – Zalo Dark Mode",
-  "version": "9.33",
+  "version": "9.33.1",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "Quaric",

--- a/src/web/vendor/firefox/manifest.json
+++ b/src/web/vendor/firefox/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "ZaDark – Zalo Dark Mode",
-  "version": "9.33",
+  "version": "9.33.1",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "Quaric",

--- a/src/web/vendor/safari/manifest.json
+++ b/src/web/vendor/safari/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "ZaDark for Safari",
-  "version": "9.33",
+  "version": "9.33.1",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "Quaric",


### PR DESCRIPTION
…dd fix for Extension Popup

docs(package.json): update version to 24.8.1
refactor(popup.js): change ZaDarkUtils to ZaDarkShared for debounce function
feat(popup.html): add script src for zadark-shared.min.js
feat(manifest.json): update versions to 9.33.1 for Chrome, Edge, Firefox, and Safari extensions