### PR TITLE
chore(release): bump version to 24.9.1 in package.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## ZaDark 24.9.1
+
+> PC 14.0.2 và Web 9.33.2
+
+- Hỗ trợ ảnh nền cuộc trò chuyện ở giao diện **Sáng** ([#142](https://github.com/quaric/zadark/issues/142))
+
 ## ZaDark 24.8.3
 
 > PC 14.0.1

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadark",
   "description": "Dark Mode tốt nhất cho Zalo",
-  "version": "24.8.3",
+  "version": "24.9.1",
   "repository": "https://github.com/quaric/zadark.git",
   "author": {
     "name": "Quaric",

--- a/src/core/scss/zadark.scss
+++ b/src/core/scss/zadark.scss
@@ -687,17 +687,6 @@ html[data-zadark-theme="dark"] {
       padding: 16px;
     }
 
-    .message-view {
-      &__blur__overlay {
-        &,
-        &_noavatar {
-          background-image: var(--zadark-thread-chat-bg-url, var(--message-view-gradient));
-          // background-size: cover;
-          // background-position: center;
-        }
-      }
-    }
-
     .media-tabs__main {
       border-bottom-color: var(--border);
 
@@ -2339,6 +2328,7 @@ body.zadark {
     &__blur__overlay {
       &,
       &_noavatar {
+        background-image: var(--zadark-thread-chat-bg-url, var(--message-view-gradient));
         background-size: cover;
         background-position: center;
       }
@@ -2384,6 +2374,7 @@ body.zadark {
       overflow: hidden;
       border-radius: var(--zadark-rounded-base);
       box-shadow: var(--popper-shadow);
+      margin-left: -1px;
 
       #js-btn-scroll {
         bottom: 16px;

--- a/src/pc/package.json
+++ b/src/pc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadark-pc",
   "description": "Dark Mode tốt nhất cho Zalo",
-  "version": "14.0.1",
+  "version": "14.0.2",
   "main": "index.js",
   "repository": "https://github.com/quaric/zadark.git",
   "author": {

--- a/src/web/vendor/chrome/manifest.json
+++ b/src/web/vendor/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ZaDark – Zalo Dark Mode",
-  "version": "9.33.1",
+  "version": "9.33.2",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "Quaric",

--- a/src/web/vendor/edge/manifest.json
+++ b/src/web/vendor/edge/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ZaDark – Zalo Dark Mode",
-  "version": "9.33.1",
+  "version": "9.33.2",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "Quaric",

--- a/src/web/vendor/firefox/manifest.json
+++ b/src/web/vendor/firefox/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "ZaDark – Zalo Dark Mode",
-  "version": "9.33.1",
+  "version": "9.33.2",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "Quaric",

--- a/src/web/vendor/safari/manifest.json
+++ b/src/web/vendor/safari/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "ZaDark for Safari",
-  "version": "9.33.1",
+  "version": "9.33.2",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "Quaric",


### PR DESCRIPTION
chore(release): update changelog for version 24.9.1
fix(scss): move background-image property to correct selector
fix(scss): add margin-left to popper element for better alignment
chore(pc): bump version to 14.0.2 in package.json
chore(web): bump version to 9.33.2 in manifest.json for all browsers