### PR TITLE
chore(release): bump version to 24.9.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## ZaDark 24.9.6
+
+> PC 15.0.1 và Web 9.33.7
+
+- Cập nhật giao diện **Menu trái** ở chế độ **Sáng** ([#152](https://github.com/quaric/zadark/issues/152))
+
 ## ZaDark 24.9.5
 
 > PC 15.0 và Web 9.33.6

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadark",
   "description": "Dark Mode tốt nhất cho Zalo",
-  "version": "24.9.5",
+  "version": "24.9.6",
   "repository": "https://github.com/quaric/zadark.git",
   "author": {
     "name": "Quaric",

--- a/src/core/scss/zadark.scss
+++ b/src/core/scss/zadark.scss
@@ -622,8 +622,23 @@ html[data-zadark-theme="light"] {
     --popper-shadow: var(--BA50) 0px 0px 0px 5000px;
     --prv-sticker-filter: invert(0.5) brightness(2);
 
-    --zadark-custom-leftbar-text: #fff;
-    --zadark-custom-leftbar-text-hover: #fff;
+    --zadark-custom-leftmenu-text: #7589a3;
+    --zadark-custom-leftmenu-text-hover: #005ae0;
+
+    --layer-background-leftmenu: #fff;
+    --layer-background-leftmenu-hover: #e5efff;
+    --layer-background-leftmenu-selected: #e5efff;
+  }
+
+  .zadark {
+    #main-tab {
+      border-right: 1px solid var(--border);
+    }
+
+    .tds-banner-download__container {
+      background-color: var(--NG10);
+      border-bottom: 1px solid var(--border);
+    }
   }
 }
 
@@ -633,8 +648,8 @@ html[data-zadark-theme="dark"] {
 
     --prv-sticker-filter: invert(0.5);
 
-    --zadark-custom-leftbar-text: var(--N80);
-    --zadark-custom-leftbar-text-hover: var(--text-primary);
+    --zadark-custom-leftmenu-text: var(--N80);
+    --zadark-custom-leftmenu-text-hover: var(--text-primary);
   }
 
   // Scrollbar
@@ -2253,7 +2268,7 @@ body.zadark {
 
   .leftbar-tab {
     height: 56px;
-    color: var(--zadark-custom-leftbar-text);
+    color: var(--zadark-custom-leftmenu-text);
 
     &:before {
       content: "";
@@ -2272,7 +2287,7 @@ body.zadark {
 
     &:hover {
       background-color: transparent;
-      color: var(--zadark-custom-leftbar-text-hover);
+      color: var(--zadark-custom-leftmenu-text-hover);
 
       &:before {
         opacity: 1;
@@ -2287,7 +2302,7 @@ body.zadark {
     &.chat-message.last-selected,
     &.selected {
       background-color: transparent;
-      color: var(--zadark-custom-leftbar-text-hover);
+      color: var(--zadark-custom-leftmenu-text-hover);
 
       &:before {
         opacity: 1;

--- a/src/pc/package.json
+++ b/src/pc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadark-pc",
   "description": "Dark Mode tốt nhất cho Zalo",
-  "version": "15.0",
+  "version": "15.0.1",
   "main": "index.js",
   "repository": "https://github.com/quaric/zadark.git",
   "author": {

--- a/src/web/vendor/chrome/manifest.json
+++ b/src/web/vendor/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ZaDark – Zalo Dark Mode",
-  "version": "9.33.6",
+  "version": "9.33.7",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "Quaric",

--- a/src/web/vendor/edge/manifest.json
+++ b/src/web/vendor/edge/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ZaDark – Zalo Dark Mode",
-  "version": "9.33.6",
+  "version": "9.33.7",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "Quaric",

--- a/src/web/vendor/firefox/manifest.json
+++ b/src/web/vendor/firefox/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "ZaDark – Zalo Dark Mode",
-  "version": "9.33.6",
+  "version": "9.33.7",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "Quaric",

--- a/src/web/vendor/safari/manifest.json
+++ b/src/web/vendor/safari/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "ZaDark for Safari",
-  "version": "9.33.6",
+  "version": "9.33.7",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "Quaric",


### PR DESCRIPTION
docs(changelog): update changelog for version 24.9.6
fix(styles): update light mode left menu styles for better readability
chore(pc): bump version to 15.0.1
chore(web): bump version to 9.33.7 for all web vendors