### PR TITLE
fix(zadark.scss): correct dark mode styling for zCloud Promo content …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## ZaDark 24.11.1
+
+> PC 15.0.2 và Web 9.33.8
+
+- Sửa lỗi Dark Mode `zCloud Promo`
+
 ## ZaDark 24.9.6
 
 > PC 15.0.1 và Web 9.33.7

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadark",
   "description": "Dark Mode tốt nhất cho Zalo",
-  "version": "24.9.6",
+  "version": "24.11.1",
   "repository": "https://github.com/quaric/zadark.git",
   "author": {
     "name": "Quaric",

--- a/src/core/scss/zadark.scss
+++ b/src/core/scss/zadark.scss
@@ -2200,6 +2200,13 @@ html[data-zadark-theme="dark"] {
       color: var(--tab-active);
       border-bottom: 2px solid var(--tab-active);
     }
+
+    .zcloud-promo-content {
+      background: var(--layer-background);
+    }
+    .zcloud-promo-content__close-btn {
+      color: var(--text-secondary);
+    }
   }
 }
 

--- a/src/pc/package.json
+++ b/src/pc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadark-pc",
   "description": "Dark Mode tốt nhất cho Zalo",
-  "version": "15.0.1",
+  "version": "15.0.2",
   "main": "index.js",
   "repository": "https://github.com/quaric/zadark.git",
   "author": {

--- a/src/web/vendor/chrome/manifest.json
+++ b/src/web/vendor/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ZaDark – Zalo Dark Mode",
-  "version": "9.33.7",
+  "version": "9.33.8",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "Quaric",

--- a/src/web/vendor/edge/manifest.json
+++ b/src/web/vendor/edge/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ZaDark – Zalo Dark Mode",
-  "version": "9.33.7",
+  "version": "9.33.8",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "Quaric",

--- a/src/web/vendor/firefox/manifest.json
+++ b/src/web/vendor/firefox/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "ZaDark – Zalo Dark Mode",
-  "version": "9.33.7",
+  "version": "9.33.8",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "Quaric",

--- a/src/web/vendor/safari/manifest.json
+++ b/src/web/vendor/safari/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "ZaDark for Safari",
-  "version": "9.33.7",
+  "version": "9.33.8",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "Quaric",


### PR DESCRIPTION
…and close button

chore(release): bump version numbers for PC, Web, and extensions

docs(CHANGELOG.md): update changelog with latest version and fixes