### PR TITLE
chore(release): update version to 25.1.1 and changelog for new release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## ZaDark 25.1.1
+
+> PC 15.1.6 và Web 9.34.4
+
+- Sửa lỗi Dark Mode
+- Sửa lỗi "Cỡ chữ của tin nhắn"
+
 ## ZaDark 24.12.6
 
 > PC 15.1.5 và Web 9.34.3

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadark",
   "description": "Dark Mode tốt nhất cho Zalo",
-  "version": "24.12.6",
+  "version": "25.1.1",
   "repository": "https://github.com/quaric/zadark.git",
   "author": {
     "name": "Quaric",

--- a/src/core/scss/zadark.scss
+++ b/src/core/scss/zadark.scss
@@ -494,6 +494,8 @@
   --accent-grey-bg: var(--N20);
   --accent-grey-bg-bold: var(--N30);
 
+  --floating-menu: var(--N10);
+
   // Buttons
 
   --button-primary-normal: var(--B55);
@@ -2488,6 +2490,13 @@ body.zadark {
     a,
     .text,
     .editor-input {
+      font-size: var(--zadark-cnv-font-size);
+    }
+  }
+  // * Zalo >= v24.12.2
+  .card .text-message__container {
+    div-15,
+    span-15 {
       font-size: var(--zadark-cnv-font-size);
     }
   }

--- a/src/pc/package.json
+++ b/src/pc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zadark-pc",
   "description": "Dark Mode tốt nhất cho Zalo",
-  "version": "15.1.5",
+  "version": "15.1.6",
   "main": "index.js",
   "repository": "https://github.com/quaric/zadark.git",
   "author": {

--- a/src/web/vendor/chrome/manifest.json
+++ b/src/web/vendor/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ZaDark – Zalo Dark Mode",
-  "version": "9.34.3",
+  "version": "9.34.4",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "Quaric",

--- a/src/web/vendor/edge/manifest.json
+++ b/src/web/vendor/edge/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ZaDark – Zalo Dark Mode",
-  "version": "9.34.3",
+  "version": "9.34.4",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "Quaric",

--- a/src/web/vendor/firefox/manifest.json
+++ b/src/web/vendor/firefox/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "ZaDark – Zalo Dark Mode",
-  "version": "9.34.3",
+  "version": "9.34.4",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "Quaric",

--- a/src/web/vendor/safari/manifest.json
+++ b/src/web/vendor/safari/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "ZaDark for Safari",
-  "version": "9.34.3",
+  "version": "9.34.4",
   "description": "__MSG_appDesc__",
   "default_locale": "vi",
   "author": "Quaric",


### PR DESCRIPTION
fix(scss): resolve dark mode and message font size issues

chore(pc): bump version to 15.1.6 in package.json

chore(web): update version to 9.34.4 in chrome, edge, firefox, and safari manifests